### PR TITLE
Adds min-width to toc.

### DIFF
--- a/app/assets/stylesheets/TableOfContents.sass
+++ b/app/assets/stylesheets/TableOfContents.sass
@@ -31,6 +31,7 @@
     margin: 0
     margin-bottom: 1em
     padding: 0
+    width: 100%
 
   &__link
     color: $white
@@ -50,7 +51,6 @@
     display: flex
     align-items: center
     min-height: 22px
-    min-width: 19.2em
 
   &__link:first-child &__item
     border-top: none
@@ -92,7 +92,6 @@
 
     &__item-data
       margin-left: -40px
-      min-width: 14.9em
 
     &__number
       flex: 0 0 40px

--- a/app/assets/stylesheets/TableOfContents.sass
+++ b/app/assets/stylesheets/TableOfContents.sass
@@ -50,6 +50,7 @@
     display: flex
     align-items: center
     min-height: 22px
+    min-width: 19.2em
 
   &__link:first-child &__item
     border-top: none
@@ -91,6 +92,7 @@
 
     &__item-data
       margin-left: -40px
+      min-width: 14.9em
 
     &__number
       flex: 0 0 40px

--- a/app/components/BillboardTitle.js
+++ b/app/components/BillboardTitle.js
@@ -30,7 +30,7 @@ const BillboardTitle = ({ editing, slug, kicker, title, photoCredit, caseAuthors
   return <div className="BillboardTitle pt-dark" style={background}>
     <h1>
       <span className="c-kicker">
-        <EditableText value={kicker} disabled={!editing || minimal}
+        <EditableText multiline value={kicker} disabled={!editing || minimal}
           placeholder="Snappy kicker"
           onChange={value => updateCase(slug, {kicker: value})}
         />


### PR DESCRIPTION
When there is not a long enough page title, the toc on cover page and sidebar appears to be displayed weirdly—taking up only the middle part of the toc instead of filling up the whole line. So I added width=100% to .c-toc__list so that the content would stretch the full width. In addition, there is an issue of kicker not wrapping on side bar, so Cameron added multiline to editable content. 