### PR TITLE
Load statistics asynchronously, as needed

### DIFF
--- a/app/assets/stylesheets/Statistics.sass
+++ b/app/assets/stylesheets/Statistics.sass
@@ -33,5 +33,5 @@
     bottom: 0.2rem
   @include recolor-statistics($yellow)
 
-.PodcastPlayer
+.PodcastPlayer, .edge
   @include recolor-statistics($white)

--- a/app/components/card/index.jsx
+++ b/app/components/card/index.jsx
@@ -221,7 +221,7 @@ class CardContents extends React.Component {
         />
       }
 
-      { solid && !editable && <Statistics uri={`cards::${id}`} /> }
+      { solid && !editable && <Statistics uri={`cards/${id}`} /> }
 
       <OnScreenTracker
         targetKey={`cards/${id}`}

--- a/app/components/deprecated/OldEdgenote.jsx
+++ b/app/components/deprecated/OldEdgenote.jsx
@@ -57,7 +57,7 @@ class OldEdgenoteFigure extends React.Component {
   }
 
   renderEdgenote() {
-    let {selected, contents, editing, upgrade} = this.props
+    let {slug, selected, contents, editing, upgrade} = this.props
     let {caption, format, statistics, thumbnailUrl, style} = contents
     let className = this.className()
 
@@ -70,7 +70,7 @@ class OldEdgenoteFigure extends React.Component {
       onMouseOut={() => {this.setState({hovering: false})}}
     >
       <div className="c-edgenote s-edgenote">
-        <Statistics statistics={statistics} inline={true} />
+        <Statistics uri={`edgenotes/${slug}`} inline={true} />
         <div className="c-edgenote__cover">
           <img src={`${thumbnailUrl}?w=640`} />
         </div>

--- a/app/components/edgenotes/Edgenote.jsx
+++ b/app/components/edgenotes/Edgenote.jsx
@@ -4,6 +4,7 @@ import ImageZoom from 'react-medium-image-zoom'
 import YoutubePlayer from 'react-youtube-player'
 import { EditableText } from '@blueprintjs/core'
 
+import Statistics from 'utility/Statistics'
 import Tracker from 'utility/Tracker'
 import EditableAttribute from 'utility/EditableAttribute'
 
@@ -75,6 +76,7 @@ class EdgenoteFigure extends React.Component {
       : () => null
 
     return <figure className="edge" id={slug} {...conditionalHoverCallbacks}>
+      <Statistics inline uri={`edgenotes/${slug}`} />
       <ConditionalLink onClick={activate}>
 
         { !!pullQuote || !!imageUrl || !!audioUrl ||

--- a/app/components/elements/Podcast.jsx
+++ b/app/components/elements/Podcast.jsx
@@ -130,8 +130,6 @@ class PodcastPlayer extends React.Component {
           {this.renderHosts()}
         </div>
 
-        <Statistics uri={`podcasts/${id}`} inline={true} />
-
         <audio
           src={audioUrl}
           controls="controls"
@@ -139,6 +137,8 @@ class PodcastPlayer extends React.Component {
           onPlay={this.handlePlay}
           onPause={this.handlePause}
         />
+
+        <Statistics uri={`podcasts/${id}`} inline={true} />
 
         <Tracker
           timerState={this.state.playing ? 'RUNNING' : 'PAUSED'}

--- a/app/components/elements/Podcast.jsx
+++ b/app/components/elements/Podcast.jsx
@@ -130,7 +130,7 @@ class PodcastPlayer extends React.Component {
           {this.renderHosts()}
         </div>
 
-        <Statistics statistics={statistics} inline={true} />
+        <Statistics uri={`podcasts/${id}`} inline={true} />
 
         <audio
           src={audioUrl}

--- a/app/components/redux/actions.js
+++ b/app/components/redux/actions.js
@@ -17,6 +17,7 @@ import type {
   CommentThread,
   Edgenote,
   Notification,
+  StatisticsData,
 } from 'redux/state'
 
 export type Action =
@@ -49,6 +50,7 @@ export type Action =
   HighlightEdgenoteAction |
   ActivateEdgenoteAction |
   RegisterToasterAction |
+  SetStatisticsAction |
   DisplayToastAction
 
 type GetState = () => State
@@ -194,7 +196,7 @@ export function enrollReader (readerId: string, caseSlug: string): ThunkAction {
     const enrollment = await Orchard.espalier(
       `admin/cases/${caseSlug}/readers/${readerId}/enrollments/upsert`
     )
-    dispatch(setReaderEnrollment(enrollment))
+    dispatch(setReaderEnrollment(!!enrollment))
   }
 }
 
@@ -553,6 +555,27 @@ export function highlightEdgenote (slug: string): HighlightEdgenoteAction {
 export type ActivateEdgenoteAction = { type: 'ACTIVATE_EDGENOTE', slug: string }
 export function activateEdgenote (slug: string): ActivateEdgenoteAction {
   return { type: 'ACTIVATE_EDGENOTE', slug }
+}
+
+// STATISTICS
+//
+export type SetStatisticsAction = {
+  type: 'SET_STATISTICS',
+  uri: string,
+  data: StatisticsData,
+}
+function setStatistics (
+  uri: string,
+  data: StatisticsData
+): SetStatisticsAction {
+  return { type: 'SET_STATISTICS', uri, data }
+}
+
+export function loadStatistics (uri: string): ThunkAction {
+  return async (dispatch: Dispatch) => {
+    const data = (await Orchard.harvest(`${uri}/statistics`): StatisticsData)
+    dispatch(setStatistics(uri, data))
+  }
 }
 
 // TOASTS

--- a/app/components/redux/reducers/statistics.js
+++ b/app/components/redux/reducers/statistics.js
@@ -2,7 +2,7 @@ import type { StatisticsState } from 'redux/state'
 import type { SetStatisticsAction } from 'redux/actions'
 
 export default function statistics (
-  state: StatisticsState = {},
+  state: StatisticsState = window.caseData.statistics,
   action: SetStatisticsAction,
 ): StatisticsState {
   switch (action.type) {

--- a/app/components/redux/reducers/statistics.js
+++ b/app/components/redux/reducers/statistics.js
@@ -1,13 +1,17 @@
 import type { StatisticsState } from 'redux/state'
-import type { Action } from 'redux/actions'
+import type { SetStatisticsAction } from 'redux/actions'
 
 export default function statistics (
-  state: ?StatisticsState,
-  action: Action,
+  state: StatisticsState = {},
+  action: SetStatisticsAction,
 ): StatisticsState {
-  if (typeof state === 'undefined') {
-    return (window.caseData.statistics: StatisticsState) || {}
-  }
+  switch (action.type) {
+    case 'SET_STATISTICS':
+      return {
+        ...state,
+        [action.uri]: action.data,
+      }
 
-  return state
+    default: return state
+  }
 }

--- a/app/components/redux/state.js
+++ b/app/components/redux/state.js
@@ -74,13 +74,8 @@ export type PodcastsState = {
   +[podcastId: string]: Podcast,
 }
 
-export type StatisticsState = {
-  +[trackableUri: string]: {
-    +averageTime: string,
-    +uniques: number,
-    +views: number,
-    +updatedAt: number,
-  },
+export type StatisticsState = false | {
+  +[trackableUri: string]: Statistics,
 }
 
 export type UIState = {
@@ -235,4 +230,13 @@ export type Reader = {
     +editor: boolean,
     +invisible: boolean,
   },
+}
+
+export type Statistics = { +loaded: true } & StatisticsData | { +loaded: false }
+
+export type StatisticsData = {
+  +averageTime: string,
+  +uniques: number,
+  +views: number,
+  +updatedAt: number,
 }

--- a/app/components/shared/orchard.js
+++ b/app/components/shared/orchard.js
@@ -27,7 +27,7 @@ export class Orchard {
   }
 
   // Train a fruit tree to grow into a desired figure.
-  static espalier (endpoint: string, params: Object): Promise<Object> {
+  static espalier (endpoint: string, params: ?Object): Promise<Object> {
     let body = JSON.stringify(params)
     let r = new Request(
       `/${window.i18n.locale}/${endpoint}.json`, {

--- a/app/components/utility/Statistics.jsx
+++ b/app/components/utility/Statistics.jsx
@@ -29,8 +29,8 @@ type Props = { visible: false } |
 class Statistics extends React.Component {
   props: Props
 
-  _maybeFetchStatistics (statistics, uri) {
-    if (!statistics) {
+  _maybeFetchStatistics ({ visible, statistics, uri }: Props = this.props) {
+    if (visible && !statistics) {
       this.props.loadStatistics(uri)
     }
   }
@@ -39,11 +39,11 @@ class Statistics extends React.Component {
     super(props)
     this._maybeFetchStatistics = this._maybeFetchStatistics.bind(this)
 
-    this._maybeFetchStatistics(props.statistics, props.uri)
+    this._maybeFetchStatistics()
   }
 
-  componentWillReceiveProps ({ statistics, uri }) {
-    this._maybeFetchStatistics(statistics, uri)
+  componentWillReceiveProps (nextProps) {
+    this._maybeFetchStatistics(nextProps)
   }
 
   render () {

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -61,10 +61,9 @@ class CasesController < ApplicationController
       @case = Case.where(slug: slug).includes(
         :podcasts,
         :edgenotes,
-        pages: [:cards],
-        cards: [comment_threads: [:comments]],
-        comment_threads: [:comments],
-        comments: [:reader],
+        activities: [:case_element, :card],
+        pages: [:case_element, :cards],
+        cards: [comment_threads: [:reader, comments: [:reader]]],
         enrollments: [:reader]
       ).first
     end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -10,8 +10,8 @@ class StatisticsController < ApplicationController
 
   private
   def set_trackable
-    @trackable = Card.find(params[:card_id])
-    @trackable ||= Podcast.find(params[:podcast_id])
-    @trackable ||= Edgenote.find(params[:edgenote_id])
+    @trackable = params[:card_id] && Card.find(params[:card_id])
+    @trackable ||= params[:podcast_id] && Podcast.find(params[:podcast_id])
+    @trackable ||= params[:edgenote_slug] && Edgenote.find_by_slug(params[:edgenote_slug])
   end
 end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,0 +1,17 @@
+class StatisticsController < ApplicationController
+  before_action :authenticate_reader!
+  before_action :set_trackable
+
+  authorize_actions_for Case, all_actions: :update
+
+  def show
+    render partial: 'trackable/statistics', locals: { trackable: @trackable }
+  end
+
+  private
+  def set_trackable
+    @trackable = Card.find(params[:card_id])
+    @trackable ||= Podcast.find(params[:podcast_id])
+    @trackable ||= Edgenote.find(params[:edgenote_id])
+  end
+end

--- a/app/views/cases/_case.json.jbuilder
+++ b/app/views/cases/_case.json.jbuilder
@@ -47,7 +47,9 @@ if c.commentable && current_reader
 end
 
 if current_user.has_cached_role?(:editor)
-  json.statistics {}
+  json.statistics do
+    json.keep true
+  end
 else
   json.statistics false
 end

--- a/app/views/cases/_case.json.jbuilder
+++ b/app/views/cases/_case.json.jbuilder
@@ -47,13 +47,7 @@ if c.commentable && current_reader
 end
 
 if current_user.has_cached_role?(:editor)
-  json.statistics do
-    c.cards.each do |card|
-        json.set! "cards/#{card.id}" do
-          json.partial! "trackable/statistics", locals: { trackable: card }
-        end
-    end
-  end
+  json.statistics {}
 else
   json.statistics false
 end

--- a/app/views/edgenotes/_edgenote.json.jbuilder
+++ b/app/views/edgenotes/_edgenote.json.jbuilder
@@ -3,5 +3,3 @@ json.extract! edgenote, *%i{slug caption format thumbnail_url content
                             website_url embed_code instructions image_url
                             pdf_url photo_credit style pull_quote attribution
                             call_to_action audio_url youtube_slug}
-
-json.partial! 'trackable/statistics', locals: {trackable: edgenote}

--- a/app/views/podcasts/_podcast.json.jbuilder
+++ b/app/views/podcasts/_podcast.json.jbuilder
@@ -7,4 +7,3 @@ json.icon_slug "toc-podcast"
 json.case_element do
   json.partial! podcast.case_element
 end
-json.partial! 'trackable/statistics', locals: {trackable: podcast}

--- a/app/views/trackable/_statistics.json.jbuilder
+++ b/app/views/trackable/_statistics.json.jbuilder
@@ -1,5 +1,4 @@
-if current_user.has_cached_role? :editor
-  json.cache! [trackable, 'statistics'], expires_in: 10.minute do
-    json.(trackable, :views, :uniques, :average_time)
-  end
+json.key_format! camelize: :lower
+json.cache! [trackable, 'statistics'], expires_in: 1.minute do
+  json.(trackable, :views, :uniques, :average_time)
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,7 +57,6 @@ Rails.application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.console = true
-    Bullet.bullet_logger = true
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
       resources :activities, shallow: true
       resources :podcasts, shallow: true
       resources :pages, only: %i(create)
-      resources :edgenotes, shallow: true, param: :slug
+      resources :edgenotes, shallow: true, param: :slug do
+        resource :statistics, only: %i(show)
+      end
 
       get '*react_router_location', to: 'cases#show'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
     resources :cases, except: %i(index create edit), param: :slug do
       resources :case_elements, shallow: true, only: %i(update)
       resources :activities, shallow: true
-      resources :podcasts, shallow: true
+      resources :podcasts, shallow: true do
+        resource :statistics, only: %i(show)
+      end
       resources :pages, only: %i(create)
       resources :edgenotes, shallow: true, param: :slug do
         resource :statistics, only: %i(show)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     end
     resources :cards, only: %i(update destroy) do
       resources :comment_threads, only: %i(create)
+      resource :statistics, only: %i(show)
     end
 
     devise_for :readers, skip: :omniauth_callbacks, controllers: {

--- a/spec/features/viewing_a_case_spec.rb
+++ b/spec/features/viewing_a_case_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 feature 'Viewing a case' do
-  let(:user) { create :reader }
-
   context 'as a normal user' do
+    let(:user) { create :reader }
+
     context 'a published case' do
       let!(:published_case) do
         create :case_with_elements, :published
@@ -18,6 +18,12 @@ feature 'Viewing a case' do
         click_link published_case.pages.first.title
         expect(all('.Card').count).to eq published_case.pages.first.cards.count
         expect(page).to have_selector '.DraftEditor-root'
+      end
+
+      scenario 'does not have visible statistics' do
+        click_link published_case.title
+        click_link published_case.pages.first.title
+        expect(page).not_to have_selector '.c-statistics'
       end
     end
 
@@ -57,6 +63,19 @@ feature 'Viewing a case' do
         click_link another_forthcoming_case.title
         expect(current_path).to eq root_path
       end
+    end
+  end
+
+  context 'as an editor' do
+    let(:user) { create :reader, :editor }
+    let!(:any_case) { create :case_with_elements, :in_catalog }
+
+    before { login_as user }
+
+    scenario 'statistics are visible' do
+      click_link any_case.kicker
+      click_link any_case.pages.first.title
+      expect(page).to have_selector '.c-statistics'
     end
   end
 


### PR DESCRIPTION
As an editor, opening a case takes unacceptably long due to the calculation of all statistics for all the Trackable elements at once. Instead, I've added a statistics controller which handles ajax requests from each `<Statistics />` component when it is first loaded. This reduces unnecessary computation and reduces TTFB.