### PR TITLE
Fixes Question#requiring_response_from when no custom questions

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -10,7 +10,7 @@ class Question < ApplicationRecord
 
   def self.requiring_response_from reader, in_group:
     # where.not(id: Answer.by_reader(reader).select(:question_id))
-    where <<~SQL, reader_id: reader.id, group_id: in_group.id
+    joins(:quiz).where <<~SQL, reader_id: reader.id, group_id: in_group.id
       (
         SELECT COUNT(answers.id) FROM answers
         WHERE answers.question_id = questions.id
@@ -18,7 +18,7 @@ class Question < ApplicationRecord
       ) < (
         SELECT deployments.answers_needed FROM deployments
         WHERE deployments.group_id = :group_id
-          AND deployments.quiz_id = questions.quiz_id
+          AND deployments.case_id = quizzes.case_id
       )
     SQL
   end


### PR DESCRIPTION
The questions of a customized quiz which it inherits from the template
quiz still belong to the template quiz. As a result, looking up
answers_needed from the deployment with the question's quiz_id failed
for questions that the quiz inherited. There is no deployment of the
template quiz, only of its descendent. When there are any custom
questions at all, this falsey comparison with NULL is ignored, but
without, the Quiz#requires_response_from? would never return true.

To get around this, we're looking up the deployment by case and group.
Since it is an invariant (due to what we receive from LTI / the
ownership of quizzes by cases) that deployments.case_id is unique for
group_id, quiz_id pairs and that deployments.quiz_id is unique for
group_id, case_id pairs, we can be sure this will work.