### PR TITLE
Uses Amazon SES SMTP for email delivery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,8 +68,6 @@ gem 'omniauth-lti', github: 'cbothner/omniauth-lti'
 gem 'authority'
 gem 'rolify'
 
-gem 'postmark-rails'
-
 gem 'ahoy_matey', github: 'ankane/ahoy'
 gem 'groupdate'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.0.2)
     jwt (1.5.4)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -241,12 +240,6 @@ GEM
     orm_adapter (0.5.0)
     pg (0.18.4)
     pkg-config (1.1.7)
-    postmark (1.8.1)
-      json
-      rake
-    postmark-rails (0.13.0)
-      actionmailer (>= 3.0.0)
-      postmark (~> 1.8.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -415,7 +408,6 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-lti!
   pg (~> 0.18)
-  postmark-rails
   pry
   puma (~> 3.0)
   rack-canonical-host

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
   helper :application
-  default from: 'Michigan Sustainability Cases <msc-contact@umich.edu>'
+  default from: 'Michigan Sustainability Cases <hello@learnmsc.org>'
 
   layout 'mailer'
 end

--- a/app/views/enrollment_mailer/introduce_case.markerb
+++ b/app/views/enrollment_mailer/introduce_case.markerb
@@ -16,6 +16,8 @@ You were just enrolled in a new Michigan Sustainability Case.
 <% end %>
 
 <% email_footer <<-FOOTER
-You are receiving this email because you are enrolled in a course that includes one or more [Michigan Sustainability Cases](http://www.teachmsc.org) as part of the curriculum. If this sounds wrong, send us an email at [msc-contact@umich.edu](mailto://msc-contact@umich.edu).
+You are receiving this email because you are enrolled in a course that includes
+one or more [Michigan Sustainability Cases](http://www.teachmsc.org) as part of
+the curriculum. If this sounds wrong, send us an email at hello@learnmsc.org.
 FOOTER
 %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,8 +72,14 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.default_url_options = { host: 'www.learnmsc.org' }
-  config.action_mailer.delivery_method = :postmark
-  config.action_mailer.postmark_settings = { :api_token => ENV['POSTMARK_API_TOKEN'] }
+  config.action_mailer.smtp_settings = {
+    :address => 'email-smtp.us-west-2.amazonaws.com',
+    :port => 587,
+    :user_name => ENV['SES_SMTP_USERNAME'],
+    :password => ENV['SES_SMTP_PASSWORD'],
+    :authentication => :login,
+    :enable_starttls_auto => true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'msc-contact@umich.edu'
+  config.mailer_sender = 'hello@learnmsc.org'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'AuthenticationMailer'


### PR DESCRIPTION
Since [Postmark ended their relationship with Heroku](http://support.postmarkapp.com/article/1086-heroku-deprecation-faq) and we would potentially have to pay another monthly bill, I'm taking the opportunity to move to Amazon SES and a non-UM email address. DKIM is great, and life is just easier with consolidated billing.