### PR TITLE
Switch to shioyama/mobility for internationalization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'rolify'
 gem 'ahoy_matey', github: 'ankane/ahoy'
 gem 'groupdate'
 
-gem 'trasto'
+gem 'mobility'
 gem 'http_accept_language'
 gem 'i18n_generators'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,9 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    mobility (0.1.16)
+      i18n (>= 0.6.10, < 0.9)
+      request_store (~> 1.0)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -343,8 +346,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    trasto (0.1.0)
-      pg (~> 0.10)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.1)
@@ -403,6 +404,7 @@ DEPENDENCIES
   letter_opener
   listen (~> 3.1.5)
   markerb
+  mobility
   newrelic_rpm
   omniauth-facebook
   omniauth-google-oauth2
@@ -422,7 +424,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   table_print
-  trasto
   tzinfo-data
   uglifier (>= 1.3.0)
   virtus

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -47,6 +47,6 @@ class GroupsController < ApplicationController
 
   # Only allow a trusted parameter "white list" through.
   def group_params
-    params.require(:group).permit(:name_i18n)
+    params.require(:group).permit(:name)
   end
 end

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -2,9 +2,9 @@
 
 module CasesHelper
   def translators_string(c)
-    return '' if c.translator_names.empty?
-    number = c.translator_names.count == 1 ? 'one' : 'many'
-    "#{t ".translator.#{number}"}: #{c.translator_names.to_sentence}"
+    return '' if c.translators.empty?
+    number = c.translators.count == 1 ? 'one' : 'many'
+    "#{t ".translator.#{number}"}: #{c.translators.to_sentence}"
   end
 
   def ix_cover_image(c, size)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -8,6 +8,7 @@ class Activity < ApplicationRecord
 
   include Element
 
+  include Mobility
   translates :title, :description, :pdf_url
 
   after_create_commit -> { create_card }

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -9,7 +9,7 @@ class Activity < ApplicationRecord
   include Element
 
   include Mobility
-  translates :title, :description, :pdf_url
+  translates :title, :description, :pdf_url, fallbacks: true
 
   after_create_commit -> { create_card }
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -9,6 +9,7 @@ class Card < ApplicationRecord
   belongs_to :element, polymorphic: true
   acts_as_list scope: %i[element_id element_type]
 
+  include Mobility
   translates :content, :raw_content
 
   before_save :set_case_from_element

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -10,7 +10,7 @@ class Card < ApplicationRecord
   acts_as_list scope: %i[element_id element_type]
 
   include Mobility
-  translates :content, :raw_content
+  translates :content, :raw_content, fallbacks: true
 
   before_save :set_case_from_element
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -4,6 +4,7 @@ class Case < ApplicationRecord
   include Authority::Abilities
   include Comparable
 
+  include Mobility
   translates :kicker, :title, :dek, :summary, :narrative, :translators
   enum catalog_position: %i[in_index featured]
 
@@ -48,7 +49,7 @@ class Case < ApplicationRecord
   end
 
   def other_available_locales
-    locales_for_reading_column(:title) - [I18n.locale.to_s]
+    read_attribute(:title).keys - [I18n.locale.to_s]
   end
 
   def translator_names
@@ -56,7 +57,7 @@ class Case < ApplicationRecord
   end
 
   def translator_names=(t)
-    self.translators = t.to_json
+    self.translators = t
   end
 
   def readers_by_enrollment_status

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -52,12 +52,8 @@ class Case < ApplicationRecord
     read_attribute(:title).keys - [I18n.locale.to_s]
   end
 
-  def translator_names
-    translators || []
-  end
-
-  def translator_names=(new_names)
-    self.translators = new_names
+  def translators
+    super || []
   end
 
   def readers_by_enrollment_status

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -5,7 +5,7 @@ class Case < ApplicationRecord
   include Comparable
 
   include Mobility
-  translates :kicker, :title, :dek, :summary, :narrative, :translators
+  translates :kicker, :title, :dek, :summary, :narrative, :translators, fallbacks: true
   enum catalog_position: %i[in_index featured]
 
   resourcify
@@ -53,11 +53,11 @@ class Case < ApplicationRecord
   end
 
   def translator_names
-    JSON.parse translators
+    translators || []
   end
 
-  def translator_names=(t)
-    self.translators = t
+  def translator_names=(new_names)
+    self.translators = new_names
   end
 
   def readers_by_enrollment_status

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,6 +4,7 @@ class Comment < ApplicationRecord
   belongs_to :reader
   belongs_to :comment_thread
 
+  include Mobility
   translates :content
 
   default_scope { order :created_at }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,7 +5,7 @@ class Comment < ApplicationRecord
   belongs_to :comment_thread
 
   include Mobility
-  translates :content
+  translates :content, fallbacks: true
 
   default_scope { order :created_at }
 

--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -6,6 +6,7 @@ class Edgenote < ApplicationRecord
   belongs_to :case
   belongs_to :card
 
+  include Mobility
   translates :caption, :content, :instructions, :image_url, :website_url,
              :embed_code, :photo_credit, :pdf_url, :pull_quote, :attribution,
              :call_to_action, :audio_url, :youtube_slug

--- a/app/models/edgenote.rb
+++ b/app/models/edgenote.rb
@@ -9,7 +9,7 @@ class Edgenote < ApplicationRecord
   include Mobility
   translates :caption, :content, :instructions, :image_url, :website_url,
              :embed_code, :photo_credit, :pdf_url, :pull_quote, :attribution,
-             :call_to_action, :audio_url, :youtube_slug
+             :call_to_action, :audio_url, :youtube_slug, fallbacks: true
 
   validates :format, inclusion: { in: %w[aside audio graphic link photo quote
                                          report video] }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,6 +7,7 @@ class Group < ApplicationRecord
   has_many :readers, through: :group_memberships
   has_many :deployments, dependent: :destroy
 
+  include Mobility
   translates :name
 
   validates :context_id, uniqueness: true, if: -> () { context_id.present? }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -8,7 +8,7 @@ class Group < ApplicationRecord
   has_many :deployments, dependent: :destroy
 
   include Mobility
-  translates :name
+  translates :name, fallbacks: true
 
   validates :context_id, uniqueness: true, if: -> () { context_id.present? }
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -11,5 +11,5 @@ class Page < ApplicationRecord
                                                 dependent: :destroy
 
   include Mobility
-  translates :title
+  translates :title, fallbacks: true
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -9,5 +9,7 @@ class Page < ApplicationRecord
 
   has_many :cards, -> { order position: :asc }, as: :element,
                                                 dependent: :destroy
+
+  include Mobility
   translates :title
 end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -9,7 +9,7 @@ class Podcast < ApplicationRecord
   include Element
 
   include Mobility
-  translates :title, :audio_url, :description, :credits
+  translates :title, :audio_url, :description, :credits, fallbacks: true
 
   after_create_commit -> { create_card }
 

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -8,6 +8,7 @@ class Podcast < ApplicationRecord
 
   include Element
 
+  include Mobility
   translates :title, :audio_url, :description, :credits
 
   after_create_commit -> { create_card }

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,7 +7,7 @@ class Question < ApplicationRecord
   include Mobility
   translates :content, fallbacks: true
 
-  validates :content_i18n, presence: true
+  validates :content, presence: true
   validates :correct_answer, inclusion: { in: ->(question) { question.options } },
                              if: ->(question) { !question.options.empty? }
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,7 +5,7 @@ class Question < ApplicationRecord
   belongs_to :quiz
 
   include Mobility
-  translates :content
+  translates :content, fallbacks: true
 
   validates :content_i18n, presence: true
   validates :correct_answer, inclusion: { in: ->(question) { question.options } },

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,6 +4,7 @@ class Question < ApplicationRecord
   has_many :answers
   belongs_to :quiz
 
+  include Mobility
   translates :content
 
   validates :content_i18n, presence: true

--- a/config/initializers/mobility.rb
+++ b/config/initializers/mobility.rb
@@ -1,0 +1,6 @@
+Mobility.configure do |config|
+  config.default_backend = :jsonb
+  config.accessor_method = :translates
+  config.query_method    = :i18n
+  # TODO: Deal with fallbacks...
+end

--- a/config/initializers/mobility.rb
+++ b/config/initializers/mobility.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 Mobility.configure do |config|
   config.default_backend = :jsonb
   config.accessor_method = :translates
   config.query_method    = :i18n
-  # TODO: Deal with fallbacks...
 end

--- a/config/locales/translations/am.yml
+++ b/config/locales/translations/am.yml
@@ -20,13 +20,13 @@ am:
     attributes:
       activity:
         case: :activerecord.models.case  #g
-        description_i18n: መግለጫ i18n  #g
-        pdf_url_i18n: Pdf ዩአርኤል i18n  #g
+        description: መግለጫ   #g
+        pdf_url: Pdf ዩአርኤል   #g
         position: የስራ መደቡ  #g
-        title_i18n: ርዕስ i18n  #g
+        title: ርዕስ   #g
 
       card:
-        content_i18n: የይዘት i18n  #g
+        content: የይዘት   #g
         page: :activerecord.models.page  #g
         position: የስራ መደቡ  #g
         solid: ጠንካራ  #g
@@ -41,7 +41,7 @@ am:
         cover_url: የሽፋን ዩአርኤል  #g
         edgenotes: Edgenotes  #g
         enrollments: የመመዝገቢያ  #g
-        narrative_i18n: የትረካ i18n  #g
+        narrative: የትረካ   #g
         pages: ገጾች  #g
         podcasts: ፖድካስቶች  #g
         publication_date: የታተመበት ቀን  #g
@@ -49,14 +49,14 @@ am:
         readers: አንባቢዎች  #g
         short_title: አጭር ርዕስ  #g
         slug: የቅጠል ትል  #g
-        summary_i18n: ማጠቃለያ i18n  #g
+        summary: ማጠቃለያ   #g
         tags: መለያዎች  #g
-        title_i18n: ርዕስ i18n  #g
+        title: ርዕስ   #g
         translators: ተርጓሚዎች  #g
 
       comment:
         comment_thread: :activerecord.models.comment_thread  #g
-        content_i18n: የይዘት i18n  #g
+        content: የይዘት   #g
         reader: :activerecord.models.reader  #g
 
       comment_thread:
@@ -65,10 +65,10 @@ am:
         group: :activerecord.models.group  #g
 
       edgenote:
-        caption_i18n: የመግለጫ i18n  #g
+        caption: የመግለጫ   #g
         card: :activerecord.models.card  #g
         case: :activerecord.models.case  #g
-        content_i18n: የይዘት i18n  #g
+        content: የይዘት   #g
         format: ቅርጸት  #g
         slug: የቅጠል ትል  #g
         thumbnail_url: ድንክዬ ዩ አር ኤል  #g
@@ -80,7 +80,7 @@ am:
       group:
         comment_threads: የአስተያየት ተከታታዮች  #g
         group_memberships: ቡድን አባልነት  #g
-        name_i18n: ስም i18n  #g
+        name: ስም   #g
         readers: አንባቢዎች  #g
 
       group_membership:
@@ -99,16 +99,16 @@ am:
         cards: ካርዶች  #g
         case: :activerecord.models.case  #g
         position: የስራ መደቡ  #g
-        title_i18n: ርዕስ i18n  #g
+        title: ርዕስ   #g
 
       podcast:
         artwork_url: የስነ ጥበብ ዩአርኤል  #g
-        audio_url_i18n: የተሰሚ ዩአርኤል i18n  #g
+        audio_url: የተሰሚ ዩአርኤል   #g
         case: :activerecord.models.case  #g
-        credits_i18n: ምስጋናዎች i18n  #g
-        description_i18n: መግለጫ i18n  #g
+        credits: ምስጋናዎች   #g
+        description: መግለጫ   #g
         position: የስራ መደቡ  #g
-        title_i18n: ርዕስ i18n  #g
+        title: ርዕስ   #g
 
       reader:
         authentication_token: የማረጋገጫ ማስመሰያ  #g

--- a/config/locales/translations/en.yml
+++ b/config/locales/translations/en.yml
@@ -15,9 +15,9 @@ en:
     attributes:
       activity:
         case: :activerecord.models.case  #g
-        description_i18n: Description  #g
-        pdf_url_i18n: PDF URL  #g
-        title_i18n: Title  #g
+        description: Description  #g
+        pdf_url: PDF URL  #g
+        title: Title  #g
 
       case:
         activities: Activities  #g
@@ -27,18 +27,18 @@ en:
         cover_url: Cover URL  #g
         edgenotes: Edgenotes  #g
         enrollments: Enrollments  #g
-        narrative_i18n: Narrative #g
+        narrative: Narrative #g
         podcasts: Podcasts  #g
         published: Published  #g
         readers: Readers  #g
         slug: Slug  #g
-        summary_i18n: Summary #g
+        summary: Summary #g
         tags: Tags  #g
-        title_i18n: Title #g
+        title: Title #g
 
       comment:
         comment_thread: :activerecord.models.comment_thread  #g
-        content_i18n: Content #g
+        content: Content #g
         reader: :activerecord.models.reader  #g
 
       comment_thread:
@@ -47,9 +47,9 @@ en:
         group: :activerecord.models.group  #g
 
       edgenote:
-        caption_i18n: Caption #g
+        caption: Caption #g
         case: :activerecord.models.case  #g
-        content_i18n: Content #g
+        content: Content #g
         format: Format  #g
         slug: Slug  #g
         thumbnail_url: Thumbnail URL  #g
@@ -61,7 +61,7 @@ en:
       group:
         comment_threads: Comment threads  #g
         group_memberships: Group memberships  #g
-        name_i18n: Name #g
+        name: Name #g
         readers: Readers  #g
 
       group_membership:
@@ -69,10 +69,10 @@ en:
         reader: :activerecord.models.reader  #g
 
       podcast:
-        audio_url_i18n: Audio URL #g
+        audio_url: Audio URL #g
         case: :activerecord.models.case  #g
-        description_i18n: Description #g
-        title_i18n: Title #g
+        description: Description #g
+        title: Title #g
 
       reader:
         authentication_token: Authentication token  #g

--- a/config/locales/translations/fr.yml
+++ b/config/locales/translations/fr.yml
@@ -15,9 +15,9 @@ fr:
     attributes:
       activity:
         case: :activerecord.models.case  #g
-        description_i18n: Description de i18n  #g
-        pdf_url_i18n: Pdf url i18n  #g
-        title_i18n: Titre i18n  #g
+        description: Description de   #g
+        pdf_url: Pdf url   #g
+        title: Titre   #g
 
       case:
         activities: Activités  #g
@@ -27,18 +27,18 @@ fr:
         cover_url: Cover url  #g
         edgenotes: Edgenotes  #g
         enrollments: inscriptions  #g
-        narrative_i18n: i18n narrative  #g
+        narrative:  narrative  #g
         podcasts: Podcasts  #g
         published: Publié  #g
         readers: Les lecteurs  #g
         slug: Limace  #g
-        summary_i18n: Résumé i18n  #g
+        summary: Résumé   #g
         tags: Mots clés  #g
-        title_i18n: Titre i18n  #g
+        title: Titre   #g
 
       comment:
         comment_thread: :activerecord.models.comment_thread  #g
-        content_i18n: i18n Content  #g
+        content:  Content  #g
         reader: :activerecord.models.reader  #g
 
       comment_thread:
@@ -47,9 +47,9 @@ fr:
         group: :activerecord.models.group  #g
 
       edgenote:
-        caption_i18n: Légende i18n  #g
+        caption: Légende   #g
         case: :activerecord.models.case  #g
-        content_i18n: i18n Content  #g
+        content:  Content  #g
         format: Format  #g
         slug: Limace  #g
         thumbnail_url: url Thumbnail  #g
@@ -61,7 +61,7 @@ fr:
       group:
         comment_threads: Commentaire fils  #g
         group_memberships: Les appartenances aux groupes  #g
-        name_i18n: Nom i18n  #g
+        name: Nom   #g
         readers: Les lecteurs  #g
 
       group_membership:
@@ -69,10 +69,10 @@ fr:
         reader: :activerecord.models.reader  #g
 
       podcast:
-        audio_url_i18n: url Audio i18n  #g
+        audio_url: url Audio   #g
         case: :activerecord.models.case  #g
-        description_i18n: Description de i18n  #g
-        title_i18n: Titre i18n  #g
+        description: Description de   #g
+        title: Titre   #g
 
       reader:
         authentication_token: Le jeton d'authentification  #g

--- a/config/locales/translations/ja.yml
+++ b/config/locales/translations/ja.yml
@@ -15,9 +15,9 @@ ja:
     attributes:
       activity:
         case: :activerecord.models.case  #g
-        description_i18n: 説明国際化  #g
-        pdf_url_i18n: PDFファイルのURLの国際化  #g
-        title_i18n: タイトルの国際化  #g
+        description: 説明国際化  #g
+        pdf_url: PDFファイルのURLの国際化  #g
+        title: タイトルの国際化  #g
 
       case:
         activities: 活動  #g
@@ -27,18 +27,18 @@ ja:
         cover_url: カバーのURL  #g
         edgenotes: Edgenotes  #g
         enrollments: 入学者数  #g
-        narrative_i18n: 物語の国際化  #g
+        narrative: 物語の国際化  #g
         podcasts: ポッドキャスト  #g
         published: 公開  #g
         readers: 読者  #g
         slug: ナメクジ  #g
-        summary_i18n: 概要国際化  #g
+        summary: 概要国際化  #g
         tags: タグ  #g
-        title_i18n: タイトルの国際化  #g
+        title: タイトルの国際化  #g
 
       comment:
         comment_thread: :activerecord.models.comment_thread  #g
-        content_i18n: コンテンツ国際化  #g
+        content: コンテンツ国際化  #g
         reader: :activerecord.models.reader  #g
 
       comment_thread:
@@ -47,9 +47,9 @@ ja:
         group: :activerecord.models.group  #g
 
       edgenote:
-        caption_i18n: キャプション国際化  #g
+        caption: キャプション国際化  #g
         case: :activerecord.models.case  #g
-        content_i18n: コンテンツ国際化  #g
+        content: コンテンツ国際化  #g
         format: フォーマット  #g
         slug: ナメクジ  #g
         thumbnail_url: サムネイルのURL  #g
@@ -61,7 +61,7 @@ ja:
       group:
         comment_threads: コメントスレッド  #g
         group_memberships: グループメンバーシップ  #g
-        name_i18n: 名前I18N  #g
+        name: 名前  #g
         readers: 読者  #g
 
       group_membership:
@@ -69,10 +69,10 @@ ja:
         reader: :activerecord.models.reader  #g
 
       podcast:
-        audio_url_i18n: オーディオのURLの国際化  #g
+        audio_url: オーディオのURLの国際化  #g
         case: :activerecord.models.case  #g
-        description_i18n: 説明国際化  #g
-        title_i18n: タイトルの国際化  #g
+        description: 説明国際化  #g
+        title: タイトルの国際化  #g
 
       reader:
         authentication_token: 認証トークン  #g

--- a/config/locales/translations/zh-CN.yml
+++ b/config/locales/translations/zh-CN.yml
@@ -15,9 +15,9 @@ zh-CN:
     attributes:
       activity:
         case: :activerecord.models.case  #g
-        description_i18n: 说明国际化  #g
-        pdf_url_i18n: 全文链接国际化  #g
-        title_i18n: 标题国际化  #g
+        description: 说明国际化  #g
+        pdf_url: 全文链接国际化  #g
+        title: 标题国际化  #g
 
       case:
         activities: 活动  #g
@@ -27,18 +27,18 @@ zh-CN:
         cover_url: 封面网址  #g
         edgenotes: Edgenotes  #g
         enrollments: 扩招  #g
-        narrative_i18n: 国际化叙事  #g
+        narrative: 国际化叙事  #g
         podcasts: 播客  #g
         published: 发布时间  #g
         readers: 读者  #g
         slug: 金属块  #g
-        summary_i18n: 总结国际化  #g
+        summary: 总结国际化  #g
         tags: 标签  #g
-        title_i18n: 标题国际化  #g
+        title: 标题国际化  #g
 
       comment:
         comment_thread: :activerecord.models.comment_thread  #g
-        content_i18n: 内容国际化  #g
+        content: 内容国际化  #g
         reader: :activerecord.models.reader  #g
 
       comment_thread:
@@ -47,9 +47,9 @@ zh-CN:
         group: :activerecord.models.group  #g
 
       edgenote:
-        caption_i18n: 标题国际化  #g
+        caption: 标题国际化  #g
         case: :activerecord.models.case  #g
-        content_i18n: 内容国际化  #g
+        content: 内容国际化  #g
         format: 格式  #g
         slug: 金属块  #g
         thumbnail_url: 缩略图网址  #g
@@ -61,7 +61,7 @@ zh-CN:
       group:
         comment_threads: 评论主题  #g
         group_memberships: 组成员  #g
-        name_i18n: 名称国际化  #g
+        name: 名称国际化  #g
         readers: 读者  #g
 
       group_membership:
@@ -69,10 +69,10 @@ zh-CN:
         reader: :activerecord.models.reader  #g
 
       podcast:
-        audio_url_i18n: 音频网址国际化  #g
+        audio_url: 音频网址国际化  #g
         case: :activerecord.models.case  #g
-        description_i18n: 说明国际化  #g
-        title_i18n: 标题国际化  #g
+        description: 说明国际化  #g
+        title: 标题国际化  #g
 
       reader:
         authentication_token: 认证令牌  #g

--- a/config/locales/translations/zh-TW.yml
+++ b/config/locales/translations/zh-TW.yml
@@ -15,9 +15,9 @@ zh-TW:
     attributes:
       activity:
         case: :activerecord.models.case  #g
-        description_i18n: 说明国际化  #g
-        pdf_url_i18n: 全文链接国际化  #g
-        title_i18n: 标题国际化  #g
+        description: 说明国际化  #g
+        pdf_url: 全文链接国际化  #g
+        title: 标题国际化  #g
 
       case:
         activities: 活动  #g
@@ -27,18 +27,18 @@ zh-TW:
         cover_url: 封面网址  #g
         edgenotes: Edgenotes  #g
         enrollments: 扩招  #g
-        narrative_i18n: 国际化叙事  #g
+        narrative: 国际化叙事  #g
         podcasts: 播客  #g
         published: 发布时间  #g
         readers: 读者  #g
         slug: 金属块  #g
-        summary_i18n: 总结国际化  #g
+        summary: 总结国际化  #g
         tags: 标签  #g
-        title_i18n: 标题国际化  #g
+        title: 标题国际化  #g
 
       comment:
         comment_thread: :activerecord.models.comment_thread  #g
-        content_i18n: 内容国际化  #g
+        content: 内容国际化  #g
         reader: :activerecord.models.reader  #g
 
       comment_thread:
@@ -47,9 +47,9 @@ zh-TW:
         group: :activerecord.models.group  #g
 
       edgenote:
-        caption_i18n: 标题国际化  #g
+        caption: 标题国际化  #g
         case: :activerecord.models.case  #g
-        content_i18n: 内容国际化  #g
+        content: 内容国际化  #g
         format: 格式  #g
         slug: 金属块  #g
         thumbnail_url: 缩略图网址  #g
@@ -61,7 +61,7 @@ zh-TW:
       group:
         comment_threads: 评论主题  #g
         group_memberships: 组成员  #g
-        name_i18n: 名称国际化  #g
+        name: 名称国际化  #g
         readers: 读者  #g
 
       group_membership:
@@ -69,10 +69,10 @@ zh-TW:
         reader: :activerecord.models.reader  #g
 
       podcast:
-        audio_url_i18n: 音频网址国际化  #g
+        audio_url: 音频网址国际化  #g
         case: :activerecord.models.case  #g
-        description_i18n: 说明国际化  #g
-        title_i18n: 标题国际化  #g
+        description: 说明国际化  #g
+        title: 标题国际化  #g
 
       reader:
         authentication_token: 认证令牌  #g

--- a/db/migrate/20170706155100_convert_from_trasto_to_mobility.rb
+++ b/db/migrate/20170706155100_convert_from_trasto_to_mobility.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+class ConvertFromTrastoToMobility < ActiveRecord::Migration[5.0]
+  def change
+    # Add JSONB columns
+    add_column :activities, :title, :jsonb, default: ''
+    add_column :activities, :description, :jsonb, default: ''
+    add_column :activities, :pdf_url, :jsonb, default: ''
+    add_column :cards, :content, :jsonb, default: ''
+    add_column :cards, :raw_content, :jsonb, default: ''
+    add_column :cases, :title, :jsonb, default: ''
+    add_column :cases, :summary, :jsonb, default: ''
+    add_column :cases, :narrative, :jsonb, default: ''
+    add_column :cases, :translators, :jsonb, default: ''
+    add_column :cases, :kicker, :jsonb, default: ''
+    add_column :cases, :dek, :jsonb, default: ''
+    add_column :comments, :content, :jsonb, default: ''
+    add_column :edgenotes, :caption, :jsonb, default: ''
+    add_column :edgenotes, :content, :jsonb, default: ''
+    add_column :edgenotes, :instructions, :jsonb, default: ''
+    add_column :edgenotes, :image_url, :jsonb, default: ''
+    add_column :edgenotes, :website_url, :jsonb, default: ''
+    add_column :edgenotes, :embed_code, :jsonb, default: ''
+    add_column :edgenotes, :photo_credit, :jsonb, default: ''
+    add_column :edgenotes, :pdf_url, :jsonb, default: ''
+    add_column :edgenotes, :pull_quote, :jsonb, default: ''
+    add_column :edgenotes, :attribution, :jsonb, default: ''
+    add_column :edgenotes, :call_to_action, :jsonb, default: ''
+    add_column :edgenotes, :audio_url, :jsonb, default: ''
+    add_column :edgenotes, :youtube_slug, :jsonb, default: ''
+    add_column :groups, :name, :jsonb, default: ''
+    add_column :pages, :title, :jsonb, default: ''
+    add_column :podcasts, :title, :jsonb, default: ''
+    add_column :podcasts, :audio_url, :jsonb, default: ''
+    add_column :podcasts, :description, :jsonb, default: ''
+    add_column :podcasts, :credits, :jsonb, default: ''
+    add_column :questions, :content, :jsonb, default: ''
+
+    # Copy data
+    reversible do |dir|
+      dir.up do
+        Activity.update_all 'title = hstore_to_jsonb(title_i18n)'
+        Activity.update_all 'description = hstore_to_jsonb(description_i18n)'
+        Activity.update_all 'pdf_url = hstore_to_jsonb(pdf_url_i18n)'
+        Card.update_all 'content = hstore_to_jsonb(content_i18n)'
+        Card.update_all 'raw_content = hstore_to_jsonb(raw_content_i18n)'
+        Case.update_all 'title = hstore_to_jsonb(title_i18n)'
+        Case.update_all 'summary = hstore_to_jsonb(summary_i18n)'
+        Case.update_all 'narrative = hstore_to_jsonb(narrative_i18n)'
+        Case.update_all 'translators = hstore_to_jsonb(translators_i18n)'
+
+        Case.all.each do |c|
+          translators = c.read_attribute(:translators).each_pair.each_with_object({}) do |pair, h|
+            h[pair.first] = JSON.parse pair.second
+          end
+          c.write_attribute :translators, translators
+          c.save
+        end
+
+        Case.update_all 'kicker = hstore_to_jsonb(kicker_i18n)'
+        Case.update_all 'dek = hstore_to_jsonb(dek_i18n)'
+        Comment.update_all 'content = hstore_to_jsonb(content_i18n)'
+        Edgenote.update_all 'caption = hstore_to_jsonb(caption_i18n)'
+        Edgenote.update_all 'content = hstore_to_jsonb(content_i18n)'
+        Edgenote.update_all 'instructions = hstore_to_jsonb(instructions_i18n)'
+        Edgenote.update_all 'image_url = hstore_to_jsonb(image_url_i18n)'
+        Edgenote.update_all 'website_url = hstore_to_jsonb(website_url_i18n)'
+        Edgenote.update_all 'embed_code = hstore_to_jsonb(embed_code_i18n)'
+        Edgenote.update_all 'photo_credit = hstore_to_jsonb(photo_credit_i18n)'
+        Edgenote.update_all 'pdf_url = hstore_to_jsonb(pdf_url_i18n)'
+        Edgenote.update_all 'pull_quote = hstore_to_jsonb(pull_quote_i18n)'
+        Edgenote.update_all 'attribution = hstore_to_jsonb(attribution_i18n)'
+        Edgenote.update_all 'call_to_action = hstore_to_jsonb(call_to_action_i18n)'
+        Edgenote.update_all 'audio_url = hstore_to_jsonb(audio_url_i18n)'
+        Edgenote.update_all 'youtube_slug = hstore_to_jsonb(youtube_slug_i18n)'
+        Group.update_all 'name = hstore_to_jsonb(name_i18n)'
+        Page.update_all 'title = hstore_to_jsonb(title_i18n)'
+        Podcast.update_all 'title = hstore_to_jsonb(title_i18n)'
+        Podcast.update_all 'audio_url = hstore_to_jsonb(audio_url_i18n)'
+        Podcast.update_all 'description = hstore_to_jsonb(description_i18n)'
+        Podcast.update_all 'credits = hstore_to_jsonb(credits_i18n)'
+        Question.update_all 'content = hstore_to_jsonb(content_i18n)'
+      end
+      dir.down do
+        raise ActiveRecord::IrreversibleMigration
+      end
+    end
+
+    # Remove hstore columns
+    remove_column :activities, :title_i18n, :hstore
+    remove_column :activities, :description_i18n, :hstore
+    remove_column :activities, :pdf_url_i18n, :hstore
+    remove_column :cards, :content_i18n, :hstore
+    remove_column :cards, :raw_content_i18n, :hstore
+    remove_column :cases, :title_i18n, :hstore
+    remove_column :cases, :summary_i18n, :hstore
+    remove_column :cases, :narrative_i18n, :hstore
+    remove_column :cases, :translators_i18n, :hstore, default: { 'en' => '[]' }
+    remove_column :cases, :kicker_i18n, :hstore
+    remove_column :cases, :dek_i18n, :hstore
+    remove_column :comments, :content_i18n, :hstore
+    remove_column :edgenotes, :caption_i18n, :hstore
+    remove_column :edgenotes, :content_i18n, :hstore
+    remove_column :edgenotes, :instructions_i18n, :hstore
+    remove_column :edgenotes, :image_url_i18n, :hstore
+    remove_column :edgenotes, :website_url_i18n, :hstore
+    remove_column :edgenotes, :embed_code_i18n, :hstore
+    remove_column :edgenotes, :photo_credit_i18n, :hstore
+    remove_column :edgenotes, :pdf_url_i18n, :hstore
+    remove_column :edgenotes, :pull_quote_i18n, :hstore
+    remove_column :edgenotes, :attribution_i18n, :hstore
+    remove_column :edgenotes, :call_to_action_i18n, :hstore
+    remove_column :edgenotes, :audio_url_i18n, :hstore
+    remove_column :edgenotes, :youtube_slug_i18n, :hstore
+    remove_column :groups, :name_i18n, :hstore
+    remove_column :pages, :title_i18n, :hstore
+    remove_column :podcasts, :title_i18n, :hstore
+    remove_column :podcasts, :audio_url_i18n, :hstore
+    remove_column :podcasts, :description_i18n, :hstore
+    remove_column :podcasts, :credits_i18n, :hstore
+    remove_column :questions, :content_i18n, :hstore
+
+    disable_extension 'hstore'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170705165135) do
+ActiveRecord::Schema.define(version: 20170706155100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "hstore"
 
   create_table "activities", force: :cascade do |t|
-    t.hstore   "title_i18n"
-    t.hstore   "description_i18n"
-    t.hstore   "pdf_url_i18n"
     t.integer  "case_id"
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.integer  "position"
-    t.string   "icon_slug",        default: "activity-text"
+    t.string   "icon_slug",   default: "activity-text"
+    t.jsonb    "title",       default: ""
+    t.jsonb    "description", default: ""
+    t.jsonb    "pdf_url",     default: ""
     t.index ["case_id"], name: "index_activities_on_case_id", using: :btree
   end
 
@@ -66,15 +65,15 @@ ActiveRecord::Schema.define(version: 20170705165135) do
 
   create_table "cards", force: :cascade do |t|
     t.integer  "position"
-    t.hstore   "content_i18n"
     t.integer  "page_id"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.boolean  "solid",            default: true
-    t.hstore   "raw_content_i18n"
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.boolean  "solid",        default: true
     t.string   "element_type"
     t.integer  "element_id"
     t.integer  "case_id"
+    t.jsonb    "content",      default: ""
+    t.jsonb    "raw_content",  default: ""
     t.index ["case_id"], name: "index_cards_on_case_id", using: :btree
     t.index ["element_type", "element_id"], name: "index_cards_on_element_type_and_element_id", using: :btree
     t.index ["page_id"], name: "index_cards_on_page_id", using: :btree
@@ -93,23 +92,23 @@ ActiveRecord::Schema.define(version: 20170705165135) do
 
   create_table "cases", force: :cascade do |t|
     t.boolean  "published",        default: false
-    t.hstore   "title_i18n"
-    t.text     "slug",                                    null: false
-    t.string   "authors",          default: [],                        array: true
-    t.hstore   "summary_i18n"
-    t.text     "tags",             default: [],                        array: true
-    t.hstore   "narrative_i18n"
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
+    t.text     "slug",                             null: false
+    t.string   "authors",          default: [],                 array: true
+    t.text     "tags",             default: [],                 array: true
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.string   "cover_url"
     t.date     "publication_date"
-    t.integer  "catalog_position", default: 0,            null: false
+    t.integer  "catalog_position", default: 0,     null: false
     t.text     "short_title"
-    t.hstore   "translators_i18n", default: {"en"=>"[]"}, null: false
-    t.hstore   "kicker_i18n"
-    t.hstore   "dek_i18n"
     t.text     "photo_credit"
     t.boolean  "commentable"
+    t.jsonb    "title",            default: ""
+    t.jsonb    "summary",          default: ""
+    t.jsonb    "narrative",        default: ""
+    t.jsonb    "translators",      default: ""
+    t.jsonb    "kicker",           default: ""
+    t.jsonb    "dek",              default: ""
     t.index ["slug"], name: "index_cases_on_slug", unique: true, using: :btree
     t.index ["tags"], name: "index_cases_on_tags", using: :gin
   end
@@ -133,12 +132,12 @@ ActiveRecord::Schema.define(version: 20170705165135) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.hstore   "content_i18n"
     t.integer  "reader_id"
     t.integer  "comment_thread_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.integer  "position"
+    t.jsonb    "content",           default: ""
     t.index ["comment_thread_id"], name: "index_comments_on_comment_thread_id", using: :btree
     t.index ["reader_id"], name: "index_comments_on_reader_id", using: :btree
   end
@@ -156,27 +155,27 @@ ActiveRecord::Schema.define(version: 20170705165135) do
   end
 
   create_table "edgenotes", force: :cascade do |t|
-    t.hstore   "caption_i18n"
     t.string   "format"
     t.string   "thumbnail_url"
-    t.hstore   "content_i18n"
     t.integer  "case_id"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.text     "slug",                            null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.text     "slug",                        null: false
     t.integer  "card_id"
-    t.hstore   "instructions_i18n"
-    t.hstore   "image_url_i18n"
-    t.hstore   "website_url_i18n"
-    t.hstore   "embed_code_i18n"
-    t.hstore   "photo_credit_i18n"
-    t.hstore   "pdf_url_i18n"
-    t.integer  "style",               default: 0
-    t.hstore   "pull_quote_i18n"
-    t.hstore   "attribution_i18n"
-    t.hstore   "call_to_action_i18n"
-    t.hstore   "audio_url_i18n"
-    t.hstore   "youtube_slug_i18n"
+    t.integer  "style",          default: 0
+    t.jsonb    "caption",        default: ""
+    t.jsonb    "content",        default: ""
+    t.jsonb    "instructions",   default: ""
+    t.jsonb    "image_url",      default: ""
+    t.jsonb    "website_url",    default: ""
+    t.jsonb    "embed_code",     default: ""
+    t.jsonb    "photo_credit",   default: ""
+    t.jsonb    "pdf_url",        default: ""
+    t.jsonb    "pull_quote",     default: ""
+    t.jsonb    "attribution",    default: ""
+    t.jsonb    "call_to_action", default: ""
+    t.jsonb    "audio_url",      default: ""
+    t.jsonb    "youtube_slug",   default: ""
     t.index ["card_id"], name: "index_edgenotes_on_card_id", using: :btree
     t.index ["case_id"], name: "index_edgenotes_on_case_id", using: :btree
     t.index ["slug"], name: "index_edgenotes_on_slug", unique: true, using: :btree
@@ -202,43 +201,43 @@ ActiveRecord::Schema.define(version: 20170705165135) do
   end
 
   create_table "groups", force: :cascade do |t|
-    t.hstore   "name_i18n"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
     t.string   "context_id"
+    t.jsonb    "name",       default: ""
     t.index ["context_id"], name: "index_groups_on_context_id", using: :btree
   end
 
   create_table "pages", force: :cascade do |t|
     t.integer  "position"
-    t.hstore   "title_i18n"
     t.integer  "case_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.jsonb    "title",      default: ""
     t.index ["case_id"], name: "index_pages_on_case_id", using: :btree
   end
 
   create_table "podcasts", force: :cascade do |t|
-    t.hstore   "title_i18n"
-    t.hstore   "audio_url_i18n"
-    t.hstore   "description_i18n"
     t.integer  "case_id"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.integer  "position"
     t.string   "artwork_url"
-    t.hstore   "credits_i18n"
     t.text     "photo_credit"
+    t.jsonb    "title",        default: ""
+    t.jsonb    "audio_url",    default: ""
+    t.jsonb    "description",  default: ""
+    t.jsonb    "credits",      default: ""
     t.index ["case_id"], name: "index_podcasts_on_case_id", using: :btree
   end
 
   create_table "questions", force: :cascade do |t|
     t.integer  "quiz_id"
-    t.hstore   "content_i18n"
     t.text     "correct_answer"
     t.string   "options",        default: [],              array: true
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
+    t.jsonb    "content",        default: ""
     t.index ["quiz_id"], name: "index_questions_on_quiz_id", using: :btree
   end
 


### PR DESCRIPTION
Trasto was unmaintained, which is scary but not reason enough to switch. Replacing hstore columns with jsonb, however, is a win. Now we don’t need to do anything fancy to handle translation of complex data structures, like Case#translators and more down the line. Also, it’s got an awesome query scope and straightforward, unadulterated column names.

Migrations: YES