### PR TITLE
Fixes to collapsing summary: editing and without metadata

### DIFF
--- a/app/javascript/overview/Billboard.jsx
+++ b/app/javascript/overview/Billboard.jsx
@@ -82,7 +82,10 @@ const Billboard = ({
         />
       </p>
 
-      <Less startOpen={!learningObjectives}>
+      <Less
+        startOpen={!learningObjectives}
+        disabled={!learningObjectives || editing}
+      >
         <p style={{ margin: 0 }}>
           <EditableText
             multiline

--- a/app/javascript/utility/Less.jsx
+++ b/app/javascript/utility/Less.jsx
@@ -16,12 +16,14 @@ class Less extends Component {
     height: '10em',
     prompt: 'Read more',
     startOpen: false,
+    disabled: false,
   }
   props: {
     children: React$Element<*>,
     height: string,
     prompt: string,
     startOpen: boolean,
+    disabled: boolean,
   }
   state = { open: this.props.startOpen }
 
@@ -33,32 +35,36 @@ class Less extends Component {
       : this.props.height
   }
 
-  handleToggle = () => {
-    this.setState(({ open }: { open: boolean }) => ({ open: !open }))
+  handleOpen = () => {
+    this.setState({ open: true })
   }
 
   render () {
-    const { prompt, children } = this.props
+    const { prompt, children, disabled } = this.props
     const { open } = this.state
     return (
       <OuterContainer>
-        <InnerContainer
-          open={open}
-          height={this._getHeight()}
-          innerRef={(ref: HTMLElement) => (this._innerContainer = ref)}
-          onClick={this.handleToggle}
-        >
-          {children}
-        </InnerContainer>
-        {open ||
-          <ReadMoreLink
-            role="button"
-            tabIndex="0"
-            onClick={this.handleToggle}
-            onKeyPress={acceptKeyboardClick(() => this.handleToggle())}
-          >
-            {prompt}
-          </ReadMoreLink>}
+        {disabled
+          ? children
+          : <div>
+            <InnerContainer
+              open={open}
+              height={this._getHeight()}
+              innerRef={(ref: HTMLElement) => (this._innerContainer = ref)}
+              onClick={this.handleOpen}
+            >
+              {children}
+            </InnerContainer>
+            {open ||
+            <ReadMoreLink
+              role="button"
+              tabIndex="0"
+              onClick={this.handleOpen}
+              onKeyPress={acceptKeyboardClick(() => this.handleOpen())}
+            >
+              {prompt}
+            </ReadMoreLink>}
+          </div>}
       </OuterContainer>
     )
   }


### PR DESCRIPTION
The summary should never collapse if there is no other metadata to
display underneath it. In fact, the simplest solution is that the
summary never needs to be recollapsed after it is open.

Additionally, the summary can’t collapse while it is being edited, and
besides: something about the wrapper broke the styling of the
EditableText. Now we’ll just not use an InnerContainer when editing.