### PR TITLE
Remember and display the active group for an enrollment

### DIFF
--- a/app/assets/stylesheets/CaseOverview.sass
+++ b/app/assets/stylesheets/CaseOverview.sass
@@ -20,7 +20,6 @@
     .Card.BillboardSnippet
       border-top-left-radius: 0
       border-top-right-radius: 0
-      border-top: 4px solid $lightGreen
       padding: 0.75em 2em 1em 2em
 
       @media screen and (max-width: $mobileCutoff)

--- a/app/assets/stylesheets/Sidebar.sass
+++ b/app/assets/stylesheets/Sidebar.sass
@@ -22,7 +22,6 @@
   .BillboardTitle
     padding: 1em 1em
     padding-top: 5.3em
-    border-radius: 2pt
     font-size: 80%
     h1
       margin-bottom: 0

--- a/app/controllers/authentication_strategies/omniauth_callbacks_controller.rb
+++ b/app/controllers/authentication_strategies/omniauth_callbacks_controller.rb
@@ -23,7 +23,6 @@ class AuthenticationStrategies::OmniauthCallbacksController < Devise::OmniauthCa
       linker.add_reader_to_group
 
       linker.enroll_reader_in_case @case if @case
-      session[:active_group_id] = linker.group.id if @case
 
       redirect_to redirect_url
     else

--- a/app/controllers/authentication_strategies/omniauth_callbacks_controller.rb
+++ b/app/controllers/authentication_strategies/omniauth_callbacks_controller.rb
@@ -21,9 +21,9 @@ class AuthenticationStrategies::OmniauthCallbacksController < Devise::OmniauthCa
 
       linker = LmsLinkerService.new params
       linker.add_reader_to_group
-      session[:active_group_id] = linker.group.id
 
       linker.enroll_reader_in_case @case if @case
+      session[:active_group_id] = linker.group.id if @case
 
       redirect_to redirect_url
     else

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -18,7 +18,8 @@ class CasesController < ApplicationController
     authenticate_reader! unless @case.published
     authorize_action_for @case
 
-    set_group
+    enrollment = @case.enrollments.find_by(reader: current_reader)
+    @group = enrollment.active_group || GlobalGroup.new
     @deployment = @group.deployment_for_case(@case)
 
     render layout: 'with_header'
@@ -72,16 +73,6 @@ class CasesController < ApplicationController
       cards: [comment_threads: [:reader, comments: [:reader]]],
       enrollments: [:reader]
     ).first
-  end
-
-  def set_group
-    enrollment = @case.enrollments.find_by(reader: current_reader)
-    @group = enrollment.try(:active_group)
-    return @group if @group || !enrollment
-
-    @group = Group.get_from_session! session
-    enrollment.update active_group_id: @group.id
-    @group
   end
 
   # Only allow a trusted parameter "white list" through.

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -18,7 +18,7 @@ class CasesController < ApplicationController
     authenticate_reader! unless @case.published
     authorize_action_for @case
 
-    @group = Group.active_for_session session
+    set_group
     @deployment = @group.deployment_for_case(@case)
 
     render layout: 'with_header'
@@ -72,6 +72,16 @@ class CasesController < ApplicationController
       cards: [comment_threads: [:reader, comments: [:reader]]],
       enrollments: [:reader]
     ).first
+  end
+
+  def set_group
+    enrollment = @case.enrollments.find_by(reader: current_reader)
+    @group = enrollment.try(:active_group)
+    return @group if @group || !enrollment
+
+    @group = Group.get_from_session! session
+    enrollment.update active_group_id: @group.id
+    @group
   end
 
   # Only allow a trusted parameter "white list" through.

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -18,9 +18,7 @@ class CasesController < ApplicationController
     authenticate_reader! unless @case.published
     authorize_action_for @case
 
-    enrollment = @case.enrollments.find_by(reader: current_reader)
-    @group = enrollment.active_group || GlobalGroup.new
-    @deployment = @group.deployment_for_case(@case)
+    set_group_and_deployment
 
     render layout: 'with_header'
   end
@@ -73,6 +71,12 @@ class CasesController < ApplicationController
       cards: [comment_threads: [:reader, comments: [:reader]]],
       enrollments: [:reader]
     ).first
+  end
+
+  def set_group_and_deployment
+    @enrollment = current_reader.enrollment_for_case @case
+    @group = @enrollment.try(:active_group) || GlobalGroup.new
+    @deployment = @group.deployment_for_case @case
   end
 
   # Only allow a trusted parameter "white list" through.

--- a/app/javascript/elements/Sidebar.jsx
+++ b/app/javascript/elements/Sidebar.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { Link, withRouter, matchPath } from 'react-router-dom'
 import BillboardTitle from 'overview/BillboardTitle'
+import GroupChooser from 'overview/GroupChooser'
 import { FormattedMessage } from 'react-intl'
 import TableOfContents from 'overview/TableOfContents'
 import EnrollForm from 'overview/EnrollForm'
@@ -31,6 +32,7 @@ const Sidebar = ({ commentThreadsOpen, commentsOpen, readerEnrolled }) => {
         <FormattedMessage id="case.backToOverview" />
       </Link>
       <BillboardTitle minimal />
+      <GroupChooser rounded />
       <TableOfContents readOnly />
 
       {readerEnrolled ||

--- a/app/javascript/overview/Billboard.jsx
+++ b/app/javascript/overview/Billboard.jsx
@@ -12,6 +12,7 @@ import { EditableText } from '@blueprintjs/core'
 import EditableAttribute from 'utility/EditableAttribute'
 import Less from 'utility/Less'
 import BillboardTitle from './BillboardTitle'
+import GroupChooser from './GroupChooser'
 import LearningObjectives from './LearningObjectives'
 
 import { updateCase } from 'redux/actions'
@@ -62,6 +63,7 @@ const Billboard = ({
 }: Props) =>
   <section className="Billboard">
     <BillboardTitle />
+    <GroupChooser />
     <EditableAttribute
       disabled={!editing}
       title="Base cover image URL"

--- a/app/javascript/overview/GroupChooser.jsx
+++ b/app/javascript/overview/GroupChooser.jsx
@@ -1,0 +1,44 @@
+/**
+ * @providesModule GroupChooser
+ * @flow
+ */
+
+import React from 'react'
+import { connect } from 'react-redux'
+import styled from 'styled-components'
+
+import type { State } from 'redux/state'
+
+type OwnProps = { rounded: boolean }
+function mapStateToProps ({ caseData }: State, { rounded }: OwnProps) {
+  const { reader } = caseData
+  return { rounded, activeGroup: reader && reader.activeGroup }
+}
+
+const GroupChooser = ({ activeGroup, rounded }) =>
+  <Bar empty={!activeGroup} rounded={rounded}>
+    {activeGroup &&
+      <GroupName>
+        {activeGroup.name}
+      </GroupName>}
+  </Bar>
+
+export default connect(mapStateToProps)(GroupChooser)
+
+const Bar = styled.div`
+  background-color: #373566;
+  font-size: 10pt;
+  line-height: 1.2;
+  text-align: center;
+  padding: ${({ empty }) => (empty ? '0' : '5px')};
+  border-bottom-width: 4px;
+  border-bottom-style: solid;
+  border-bottom-color: ${({ empty }) => (empty ? '#6acb72' : '#8764ea')};
+  border-radius: ${({ rounded }) => (rounded ? '0 0 2pt 2pt' : '0')};
+`
+
+const GroupName = styled.span`
+  font-weight: bold;
+  color: #d4c5ff;
+  display: inline-block;
+`

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -194,6 +194,10 @@ export type Edgenote = {
   youtubeSlug: string,
 }
 
+export type Group = {
+  name: string,
+}
+
 export type ReplyToThreadNotification = {
   notifier: {
     // instance of Reader
@@ -259,6 +263,7 @@ export type Question = {
 }
 
 export type Reader = {
+  activeGroup: ?Group,
   canUpdateCase: boolean,
   email: string,
   enrollment: ?{

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -24,6 +24,7 @@ class Deployment < ApplicationRecord
   end
 
   def reader_needs_posttest?(reader)
+    return false unless quiz
     answers_needed - quiz.number_of_responses_from(reader) >= 1
   end
 end

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -10,8 +10,9 @@ class Enrollment < ApplicationRecord
 
   enum status: %i[student instructor treatment]
 
-  def self.upsert(case_id:, reader_id:, status: :student)
+  def self.upsert(case_id:, reader_id:, active_group_id: nil, status: :student)
     enrollment = find_or_initialize_by(case_id: case_id, reader_id: reader_id)
+    enrollment.active_group_id = active_group_id
     enrollment.status = status
     enrollment.save! if enrollment.changed?
     enrollment

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -6,6 +6,8 @@ class Enrollment < ApplicationRecord
   belongs_to :reader
   belongs_to :case
 
+  belongs_to :active_group, class_name: 'Group'
+
   enum status: %i[student instructor treatment]
 
   def self.upsert(case_id:, reader_id:, status: :student)

--- a/app/models/global_group.rb
+++ b/app/models/global_group.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class GlobalGroup
+  def id
+    nil
+  end
+
   def deployment_for_case(_)
     GenericDeployment.new
   end

--- a/app/models/global_group.rb
+++ b/app/models/global_group.rb
@@ -4,4 +4,8 @@ class GlobalGroup
   def deployment_for_case(_)
     GenericDeployment.new
   end
+
+  def active?
+    false
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -19,8 +19,10 @@ class Group < ApplicationRecord
     group
   end
 
-  def self.active_for_session(s)
-    find_by_id(s[:active_group_id]) || GlobalGroup.new
+  # Return the group referenced in the session cookie. Also, remove that
+  # reference from the session
+  def self.get_from_session!(s)
+    find_by_id(s.delete(:active_group_id)) || GlobalGroup.new
   end
 
   def deployment_for_case(kase)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -26,4 +26,8 @@ class Group < ApplicationRecord
   def deployment_for_case(kase)
     deployments.find_by(case: kase) || GenericDeployment.new
   end
+
+  def active?
+    true
+  end
 end

--- a/app/services/lms_linker_service.rb
+++ b/app/services/lms_linker_service.rb
@@ -39,6 +39,9 @@ class LmsLinkerService
 
   def enroll_reader_in_case(kase)
     return unless reader
-    Enrollment.upsert reader_id: reader.id, case_id: kase.id, status: status
+    Enrollment.upsert reader_id: reader.id,
+                      case_id: kase.id,
+                      active_group_id: group.id,
+                      status: status
   end
 end

--- a/app/views/cases/_case.json.jbuilder
+++ b/app/views/cases/_case.json.jbuilder
@@ -42,7 +42,7 @@ if reader_signed_in?
   json.reader do
     json.partial! current_reader
     json.can_update_case current_reader.can_update? c
-    json.enrollment current_reader.enrollment_for_case(c)
+    json.enrollment @enrollment
     if @group.active?
       json.active_group do
         json.extract! @group, :id, :name

--- a/app/views/cases/_case.json.jbuilder
+++ b/app/views/cases/_case.json.jbuilder
@@ -43,6 +43,11 @@ if reader_signed_in?
     json.partial! current_reader
     json.can_update_case current_reader.can_update? c
     json.enrollment current_reader.enrollment_for_case(c)
+    if @group.active?
+      json.active_group do
+        json.extract! @group, :id, :name
+      end
+    end
   end
 
   json.quiz do

--- a/db/migrate/20170719190445_add_active_group_to_enrollments.rb
+++ b/db/migrate/20170719190445_add_active_group_to_enrollments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddActiveGroupToEnrollments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :enrollments, :active_group_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170707160226) do
+ActiveRecord::Schema.define(version: 20170719190445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -187,9 +187,10 @@ ActiveRecord::Schema.define(version: 20170707160226) do
   create_table "enrollments", force: :cascade do |t|
     t.integer  "reader_id"
     t.integer  "case_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "status",     default: 0
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.integer  "status",          default: 0
+    t.integer  "active_group_id"
     t.index ["case_id"], name: "index_enrollments_on_case_id", using: :btree
     t.index ["reader_id"], name: "index_enrollments_on_reader_id", using: :btree
   end


### PR DESCRIPTION
#### Some background:
`readers` have `enrollments` in `cases`
`groups` have `deployments` of `cases` (these include an LMS context id and are analogous to courses)

The `quiz` is attached to the `deployment`, but a reader can study a case in more than one context. Especially if the comments belong to a `group`, cf. our stratified forum plan, we will need to offer the reader a way to change the active `group` (and therefore the active `deployment`).

But the first step in that direction is remembering the active group for any given `reader`–`case`, i.e. `enrollment`. This wasn’t necessary when the only way it would matter is if the reader were coming from an LMS, but that’s unsustainable.

#### So therefore:
This PR saves the active group, as recorded in the session through an LTI launch request or our own magic link, in the reader’s enrollment in the case that link takes them to. 