### PR TITLE
Stratify the forum

### DIFF
--- a/app/assets/stylesheets/CommentThread.sass
+++ b/app/assets/stylesheets/CommentThread.sass
@@ -11,13 +11,10 @@
   position: absolute
   top: 0
   right: -290px
-  background-color: #7351D4
   width: 267px
-  color: white
   font-family: $sansFont
   font-weight: 500
   font-size: 12pt
-  box-shadow: 0 0.5em 1em rgba(0, 0, 0, 0.3)
 
   &__footer
     border-top: 1px solid #351D7A

--- a/app/channels/forum_channel.rb
+++ b/app/channels/forum_channel.rb
@@ -3,7 +3,10 @@
 # Restart the server when this file is modified.
 class ForumChannel < ApplicationCable::Channel
   def subscribed
-    stream_from 'forum_channel'
+    current_reader.reload
+    forum = current_reader.active_community.forums
+                          .find_by case: Case.find_by_slug(params[:case_slug])
+    stream_for forum
   end
 
   def unsubscribed; end

--- a/app/controllers/comment_threads_controller.rb
+++ b/app/controllers/comment_threads_controller.rb
@@ -14,6 +14,7 @@ class CommentThreadsController < ApplicationController
                        .comment_threads
                        .visible_to_reader?(current_reader)
                        .order(:block_index, :start)
+                       .includes(comments: [:reader])
   end
 
   def create
@@ -55,7 +56,7 @@ class CommentThreadsController < ApplicationController
   end
 
   def active_forum
-    Forum.find_by case: @card.case, community: current_reader.active_community
+    current_reader.active_community.forums.find_by case: @card.case
   end
 
   def comment_thread_params

--- a/app/controllers/comment_threads_controller.rb
+++ b/app/controllers/comment_threads_controller.rb
@@ -29,7 +29,11 @@ class CommentThreadsController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    current_reader.update active_community_id: @comment_thread.forum
+                                                              .community.id
+    redirect_to inline_comment_thread_url @comment_thread
+  end
 
   def destroy
     authorize_action_for @comment_thread
@@ -56,5 +60,11 @@ class CommentThreadsController < ApplicationController
 
   def comment_thread_params
     params.require(:comment_thread).permit(:start, :length, :block_index, :original_highlight_text)
+  end
+
+  def inline_comment_thread_url(comment_thread)
+    "#{case_url(I18n.locale, comment_thread.card.case.slug)}" \
+      "/#{comment_thread.card.element.case_element.position}" \
+      "/cards/#{comment_thread.card_id}/comments/#{comment_thread.id}"
   end
 end

--- a/app/controllers/comment_threads_controller.rb
+++ b/app/controllers/comment_threads_controller.rb
@@ -2,8 +2,15 @@
 
 class CommentThreadsController < ApplicationController
   before_action :authenticate_reader!
+  before_action :set_case, only: [:index]
   before_action :set_card, only: [:create]
   before_action :set_comment_thread, only: %i[show destroy]
+
+  def index
+    @comment_threads = @case.comment_threads
+                            .includes(comments: [:reader])
+                            .visible_to_reader?(current_reader)
+  end
 
   def create
     @comment_thread = @card.comment_threads.build(comment_thread_params)
@@ -28,6 +35,10 @@ class CommentThreadsController < ApplicationController
 
   def set_comment_thread
     @comment_thread = CommentThread.find params[:id]
+  end
+
+  def set_case
+    @case = Case.find_by_slug params[:case_slug]
   end
 
   def set_card

--- a/app/controllers/comment_threads_controller.rb
+++ b/app/controllers/comment_threads_controller.rb
@@ -7,14 +7,15 @@ class CommentThreadsController < ApplicationController
   before_action :set_comment_thread, only: %i[show destroy]
 
   def index
-    @comment_threads = current_reader
-                       .active_community
-                       .forums
-                       .find_by(case: @case)
-                       .comment_threads
-                       .visible_to_reader?(current_reader)
-                       .order(:block_index, :start)
-                       .includes(comments: [:reader])
+    forum = current_reader.active_community.forums.find_by(case: @case)
+    @comment_threads = if forum.nil?
+                         []
+                       else
+                         forum.comment_threads
+                              .visible_to_reader?(current_reader)
+                              .order(:block_index, :start)
+                              .includes(comments: [:reader])
+                       end
   end
 
   def create

--- a/app/controllers/comment_threads_controller.rb
+++ b/app/controllers/comment_threads_controller.rb
@@ -7,10 +7,13 @@ class CommentThreadsController < ApplicationController
   before_action :set_comment_thread, only: %i[show destroy]
 
   def index
-    @comment_threads = @case.comment_threads
-                            .includes(comments: [:reader])
-                            .visible_to_reader?(current_reader)
-                            .order(:block_index, :start)
+    @comment_threads = current_reader
+                       .active_community
+                       .forums
+                       .find_by(case: @case)
+                       .comment_threads
+                       .visible_to_reader?(current_reader)
+                       .order(:block_index, :start)
   end
 
   def create

--- a/app/controllers/comment_threads_controller.rb
+++ b/app/controllers/comment_threads_controller.rb
@@ -19,6 +19,7 @@ class CommentThreadsController < ApplicationController
   def create
     @comment_thread = @card.comment_threads.build(comment_thread_params)
     @comment_thread.reader = current_reader
+    @comment_thread.forum = active_forum
     @comment_thread.locale = I18n.locale
 
     if @comment_thread.save
@@ -47,6 +48,10 @@ class CommentThreadsController < ApplicationController
 
   def set_card
     @card = Card.find params[:card_id]
+  end
+
+  def active_forum
+    Forum.find_by case: @card.case, community: current_reader.active_community
   end
 
   def comment_thread_params

--- a/app/controllers/comment_threads_controller.rb
+++ b/app/controllers/comment_threads_controller.rb
@@ -10,6 +10,7 @@ class CommentThreadsController < ApplicationController
     @comment_threads = @case.comment_threads
                             .includes(comments: [:reader])
                             .visible_to_reader?(current_reader)
+                            .order(:block_index, :start)
   end
 
   def create

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CommunitiesController < ApplicationController
+  before_action :authenticate_reader!
+
+  def index
+    kase = Case.find_by_slug params[:case_slug]
+    @communities = [GlobalCommunity.instance] +
+                   Community.active_for_case(kase.id)
+                            .merge(current_reader.communities)
+  end
+end

--- a/app/controllers/readers_controller.rb
+++ b/app/controllers/readers_controller.rb
@@ -64,7 +64,8 @@ class ReadersController < ApplicationController
       @reader_can_set_password = @reader && !@reader.created_password
     end
 
-    permitted = %i[name initials email locale send_reply_notifications]
+    permitted = %i[name initials email locale send_reply_notifications
+                   active_community_id]
     permitted << :password if @reader_can_set_password
 
     params.require(:reader).permit(*permitted)

--- a/app/helpers/comment_threads_helper.rb
+++ b/app/helpers/comment_threads_helper.rb
@@ -6,4 +6,9 @@ module CommentThreadsHelper
       "/#{comment_thread.card.element.case_element.position}" \
       "/cards/#{comment_thread.card_id}/comments"
   end
+
+  def threads_for_card(comment_threads, card_id)
+    @comment_threads_by_card ||= comment_threads.group_by(&:card_id)
+    @comment_threads_by_card[card_id]
+  end
 end

--- a/app/helpers/comment_threads_helper.rb
+++ b/app/helpers/comment_threads_helper.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module CommentThreadsHelper
-  def comment_thread_url(locale, comment_thread)
-    "#{case_url(locale, comment_thread.card.case.slug)}" \
-      "/#{comment_thread.card.element.case_element.position}" \
-      "/cards/#{comment_thread.card_id}/comments"
-  end
-
   def threads_for_card(comment_threads, card_id)
     @comment_threads_by_card ||= comment_threads.group_by(&:card_id)
     @comment_threads_by_card[card_id]

--- a/app/javascript/Case.jsx
+++ b/app/javascript/Case.jsx
@@ -11,6 +11,7 @@ import DocumentTitle from 'react-document-title'
 import {
   parseAllCards,
   fetchCommentThreads,
+  fetchCommunities,
   registerToaster,
   addComment,
   addCommentThread,
@@ -60,11 +61,16 @@ class Case extends React.Component {
       loadComments,
       caseSlug,
       fetchCommentThreads,
+      fetchCommunities,
       registerToaster,
     } = this.props
 
     parseAllCards()
-    if (loadComments) fetchCommentThreads(caseSlug)
+
+    if (loadComments) {
+      fetchCommentThreads(caseSlug)
+      fetchCommunities(caseSlug)
+    }
 
     registerToaster(Toaster.create())
 
@@ -110,6 +116,7 @@ export default connect(
   {
     parseAllCards,
     fetchCommentThreads,
+    fetchCommunities,
     registerToaster,
     addComment,
     addCommentThread,

--- a/app/javascript/Case.jsx
+++ b/app/javascript/Case.jsx
@@ -10,6 +10,7 @@ import DocumentTitle from 'react-document-title'
 
 import {
   parseAllCards,
+  fetchCommentThreads,
   registerToaster,
   addComment,
   addCommentThread,
@@ -54,9 +55,18 @@ class Case extends React.Component {
   }
 
   componentDidMount () {
-    setTimeout(() => this.props.parseAllCards(), 1)
+    const {
+      parseAllCards,
+      commentable,
+      caseSlug,
+      fetchCommentThreads,
+      registerToaster,
+    } = this.props
 
-    this.props.registerToaster(Toaster.create())
+    parseAllCards()
+    if (commentable) fetchCommentThreads(caseSlug)
+
+    registerToaster(Toaster.create())
 
     this._subscribe()
   }
@@ -85,17 +95,20 @@ class Case extends React.Component {
 }
 
 export default connect(
-  (state: State) => ({
-    needsPretest: state.quiz.needsPretest,
-    needsPosttest: state.quiz.needsPosttest,
-    kicker: state.caseData.kicker,
+  ({ quiz, caseData }: State) => ({
+    needsPretest: quiz.needsPretest,
+    needsPosttest: quiz.needsPosttest,
+    caseSlug: caseData.slug,
+    kicker: caseData.kicker,
+    commentable: caseData.commentable,
     basename: location.pathname.replace(
-      RegExp(`${state.caseData.slug}.*`),
-      state.caseData.slug
+      RegExp(`${caseData.slug}.*`),
+      caseData.slug
     ),
   }),
   {
     parseAllCards,
+    fetchCommentThreads,
     registerToaster,
     addComment,
     addCommentThread,

--- a/app/javascript/Case.jsx
+++ b/app/javascript/Case.jsx
@@ -57,14 +57,14 @@ class Case extends React.Component {
   componentDidMount () {
     const {
       parseAllCards,
-      commentable,
+      loadComments,
       caseSlug,
       fetchCommentThreads,
       registerToaster,
     } = this.props
 
     parseAllCards()
-    if (commentable) fetchCommentThreads(caseSlug)
+    if (loadComments) fetchCommentThreads(caseSlug)
 
     registerToaster(Toaster.create())
 
@@ -100,7 +100,8 @@ export default connect(
     needsPosttest: quiz.needsPosttest,
     caseSlug: caseData.slug,
     kicker: caseData.kicker,
-    commentable: caseData.commentable,
+    loadComments:
+      caseData.commentable && caseData.reader && caseData.reader.enrollment,
     basename: location.pathname.replace(
       RegExp(`${caseData.slug}.*`),
       caseData.slug

--- a/app/javascript/Case.jsx
+++ b/app/javascript/Case.jsx
@@ -13,8 +13,7 @@ import {
   fetchCommentThreads,
   fetchCommunities,
   registerToaster,
-  addComment,
-  addCommentThread,
+  subscribeToActiveForumChannel,
   handleNotification,
 } from 'redux/actions.js'
 
@@ -30,29 +29,23 @@ import type { State } from 'redux/state'
 
 class Case extends React.Component {
   _subscribe = () => {
-    // $FlowFixMe
-    if (typeof App === 'undefined') return
-    // eslint-disable-next-line
-    App.forum = App.cable.subscriptions.create('ForumChannel', {
-      received: data => {
-        if (data.comment) {
-          this.props.addComment(JSON.parse(data.comment))
-        }
-        if (data.comment_thread) {
-          this.props.addCommentThread(JSON.parse(data.comment_thread))
-        }
-      },
-    })
+    const {
+      handleNotification,
+      subscribeToActiveForumChannel,
+      caseSlug,
+    } = this.props
 
-    // eslint-disable-next-line
+    if (typeof App === 'undefined') return
     App.readerNotification = App.cable.subscriptions.create(
       'ReaderNotificationsChannel',
       {
         received: data => {
-          this.props.handleNotification(JSON.parse(data.notification))
+          handleNotification(JSON.parse(data.notification))
         },
       }
     )
+
+    subscribeToActiveForumChannel(caseSlug)
   }
 
   componentDidMount () {
@@ -118,8 +111,7 @@ export default connect(
     fetchCommentThreads,
     fetchCommunities,
     registerToaster,
-    addComment,
-    addCommentThread,
+    subscribeToActiveForumChannel,
     handleNotification,
   }
 )(Case)

--- a/app/javascript/card/CitationTooltip.jsx
+++ b/app/javascript/card/CitationTooltip.jsx
@@ -16,8 +16,9 @@ type OwnProps = {
   openedCitation: { key: string, labelRef: any },
 }
 function mapStateToProps (state: State, ownProps: OwnProps) {
-  let { editorState } = state.cardsById[ownProps.cardId]
-  let { href, contents } = editorState
+  const editorState =
+    state.cardsById[ownProps.cardId].editorState || EditorState.createEmpty()
+  const { href, contents } = editorState
     .getCurrentContent()
     .getEntity(ownProps.openedCitation.key)
     .getData()

--- a/app/javascript/card/index.jsx
+++ b/app/javascript/card/index.jsx
@@ -122,7 +122,6 @@ function mergeProps (stateProps, dispatchProps, ownProps: OwnProps) {
 
     addCommentThread: async () => {
       if (!editable && !editorState.getSelection().isCollapsed()) {
-        // $FlowFixMe
         const threadId: string = await createCommentThread(
           ownProps.id,
           editorState

--- a/app/javascript/card/index.jsx
+++ b/app/javascript/card/index.jsx
@@ -41,7 +41,9 @@ function mapStateToProps (
   state: State,
   { id, location, nonNarrative }: OwnProps
 ) {
-  const { solid, editorState, commentThreads } = state.cardsById[id]
+  const { solid, commentThreads } = state.cardsById[id]
+  const editorState =
+    state.cardsById[id].editorState || EditorState.createEmpty()
   const { openedCitation, hoveredCommentThread, acceptingSelection } = state.ui
 
   const { pathname } = location

--- a/app/javascript/card/index.jsx
+++ b/app/javascript/card/index.jsx
@@ -41,7 +41,7 @@ function mapStateToProps (
   state: State,
   { id, location, nonNarrative }: OwnProps
 ) {
-  const { solid, editorState } = state.cardsById[id]
+  const { solid, editorState, commentThreads } = state.cardsById[id]
   const { openedCitation, hoveredCommentThread, acceptingSelection } = state.ui
 
   const { pathname } = location
@@ -53,6 +53,7 @@ function mapStateToProps (
 
   return {
     commentable:
+      commentThreads != null &&
       !nonNarrative &&
       state.caseData.commentable &&
       !!(state.caseData.reader && state.caseData.reader.enrollment),

--- a/app/javascript/comments/CommentThreadsCard.jsx
+++ b/app/javascript/comments/CommentThreadsCard.jsx
@@ -37,7 +37,7 @@ function mapStateToProps (state: State, { cardId, location }: OwnProps) {
   return {
     commentThreads: state.cardsById[cardId].commentThreads,
     acceptingSelection: state.ui.acceptingSelection,
-    selectionPending: editorState.getSelection().isCollapsed(),
+    selectionPending: !editorState.getSelection().isCollapsed(),
     closeCommentThreadsPath: params.url,
   }
 }

--- a/app/javascript/comments/CommentThreadsCard.jsx
+++ b/app/javascript/comments/CommentThreadsCard.jsx
@@ -15,6 +15,7 @@ import CommentThread from 'comments/CommentThread'
 import CommentsCard from 'comments/CommentsCard'
 import Icon from 'utility/Icon'
 
+import { EditorState } from 'draft-js'
 import { Link, Route, matchPath } from 'react-router-dom'
 import { elementOpen, commentsOpen } from 'shared/routes'
 
@@ -30,12 +31,13 @@ function mapStateToProps (state: State, { cardId, location }: OwnProps) {
     throw new Error('CommentThreadsCard should not be mounted at this route.')
   }
 
+  const editorState =
+    state.cardsById[cardId].editorState || EditorState.createEmpty()
+
   return {
     commentThreads: state.cardsById[cardId].commentThreads,
     acceptingSelection: state.ui.acceptingSelection,
-    selectionPending: !state.cardsById[cardId].editorState
-      .getSelection()
-      .isCollapsed(),
+    selectionPending: editorState.getSelection().isCollapsed(),
     closeCommentThreadsPath: params.url,
   }
 }

--- a/app/javascript/comments/CommentThreadsCard.jsx
+++ b/app/javascript/comments/CommentThreadsCard.jsx
@@ -5,6 +5,7 @@
 
 import React from 'react'
 import { connect } from 'react-redux'
+import styled from 'styled-components'
 import { Portal } from '@blueprintjs/core'
 
 import { acceptSelection } from 'redux/actions'
@@ -13,6 +14,7 @@ import { FormattedMessage } from 'react-intl'
 
 import CommentThread from 'comments/CommentThread'
 import CommentsCard from 'comments/CommentsCard'
+import CommunityChooser from 'overview/CommunityChooser'
 import Icon from 'utility/Icon'
 
 import { EditorState } from 'draft-js'
@@ -58,7 +60,7 @@ const CommentThreadsCard = ({
 
   return (
     <div className="CommentThreads">
-      <div className={`CommentThreads__window`}>
+      <CommentThreadsWindow>
         <div style={styles.header}>
           <Link
             replace
@@ -120,7 +122,13 @@ const CommentThreadsCard = ({
                 />}
           </button>
         </div>
-      </div>
+      </CommentThreadsWindow>
+
+      {acceptingSelection &&
+        selectionPending &&
+        <ChooserWindow>
+          <CommunityChooser white disabled />
+        </ChooserWindow>}
 
       {
         <Portal>
@@ -174,3 +182,14 @@ const styles = {
     padding: '0 0.5em',
   },
 }
+
+const CommentThreadsWindow = styled.div`
+  background-color: #7351d4;
+  box-shadow: 0 0.5em 1em rgba(0, 0, 0, 0.3);
+  color: white;
+`
+
+const ChooserWindow = styled.div`
+  margin-top: 1em;
+  border-radius: 2pt;
+`

--- a/app/javascript/comments/CommentThreadsCard.jsx
+++ b/app/javascript/comments/CommentThreadsCard.jsx
@@ -54,6 +54,8 @@ const CommentThreadsCard = ({
   match,
   history,
 }) => {
+  if (commentThreads == null) return null
+
   return (
     <div className="CommentThreads">
       <div className={`CommentThreads__window`}>

--- a/app/javascript/comments/CommentThreadsTag.jsx
+++ b/app/javascript/comments/CommentThreadsTag.jsx
@@ -14,11 +14,17 @@ import { Link } from 'react-router-dom'
 import type { State } from 'redux/state'
 
 type OwnProps = { cardId: string }
-function mapStateToProps (state: State, ownProps: OwnProps) {
+function mapStateToProps (
+  { cardsById, commentThreadsById }: State,
+  { cardId }: OwnProps
+) {
+  const { commentThreads } = cardsById[cardId]
+  if (commentThreads == null) return { count: 0 }
+
   return {
-    count: state.cardsById[ownProps.cardId].commentThreads
-      .map(e => state.commentThreadsById[e.id].commentIds)
-      .reduce((a, e) => [...a, ...e], []).length,
+    count: commentThreads
+      .map(e => commentThreadsById[e.id].commentsCount)
+      .reduce((a, e) => a + e, 0),
   }
 }
 

--- a/app/javascript/comments/commentThreads.js
+++ b/app/javascript/comments/commentThreads.js
@@ -3,13 +3,12 @@
  */
 
 import type { RawDraftContentState } from 'draft-js'
-import type { CommentThread } from 'redux/state'
+import type { Card } from 'redux/state'
 
-export function addCommentThreads (
-  content: RawDraftContentState,
-  { commentThreads = [] }: { commentThreads: CommentThread[] }
-) {
+export function addCommentThreads (content: RawDraftContentState, card: Card) {
   let newContent = { ...content }
+
+  const commentThreads = card.commentThreads || []
 
   commentThreads.forEach(thread => {
     const { id, blockIndex, length } = thread

--- a/app/javascript/edgenotes/index.jsx
+++ b/app/javascript/edgenotes/index.jsx
@@ -1,16 +1,23 @@
+/**
+ * @providesModule EdgenotesCard
+ * @flow
+ */
+
 import React from 'react'
 import { connect } from 'react-redux'
+import { values } from 'ramda'
+
 import { convertToRaw } from 'draft-js'
 import OldEdgenote from 'deprecated/OldEdgenote'
 import { Edgenote } from 'edgenotes/Edgenote'
 
-import typeof { EditorState } from 'draft-js'
+import { EditorState } from 'draft-js'
 import type { State } from 'redux/state'
 
 type OwnProps = { cardId: string }
 function mapStateToProps (state: State, ownProps: OwnProps) {
   let edgenoteSlugs = getEdgenoteSlugs(
-    state.cardsById[ownProps.cardId].editorState
+    state.cardsById[ownProps.cardId].editorState || EditorState.createEmpty()
   )
   return {
     oldStyle: edgenoteSlugs.some(x => state.edgenotesBySlug[x].style === 'v1'),
@@ -36,7 +43,7 @@ export default connect(mapStateToProps)(EdgenotesCard)
 
 function getEdgenoteSlugs (editorState: EditorState): string[] {
   const rawContent = convertToRaw(editorState.getCurrentContent())
-  return Object.values(rawContent.entityMap)
+  return values(rawContent.entityMap)
     .filter(entity => entity.type === 'EDGENOTE')
     .map(entity => entity.data.slug)
 }

--- a/app/javascript/elements/Sidebar.jsx
+++ b/app/javascript/elements/Sidebar.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { Link, withRouter, matchPath } from 'react-router-dom'
 import BillboardTitle from 'overview/BillboardTitle'
-import GroupChooser from 'overview/GroupChooser'
+import CommunityChooser from 'overview/CommunityChooser'
 import { FormattedMessage } from 'react-intl'
 import TableOfContents from 'overview/TableOfContents'
 import EnrollForm from 'overview/EnrollForm'
@@ -32,7 +32,7 @@ const Sidebar = ({ commentThreadsOpen, commentsOpen, readerEnrolled }) => {
         <FormattedMessage id="case.backToOverview" />
       </Link>
       <BillboardTitle minimal />
-      <GroupChooser rounded />
+      <CommunityChooser rounded />
       <TableOfContents readOnly />
 
       {readerEnrolled ||

--- a/app/javascript/overview/Billboard.jsx
+++ b/app/javascript/overview/Billboard.jsx
@@ -12,7 +12,7 @@ import { EditableText } from '@blueprintjs/core'
 import EditableAttribute from 'utility/EditableAttribute'
 import Less from 'utility/Less'
 import BillboardTitle from './BillboardTitle'
-import GroupChooser from './GroupChooser'
+import CommunityChooser from './CommunityChooser'
 import LearningObjectives from './LearningObjectives'
 
 import { updateCase } from 'redux/actions'
@@ -63,7 +63,7 @@ const Billboard = ({
 }: Props) =>
   <section className="Billboard">
     <BillboardTitle />
-    <GroupChooser />
+    <CommunityChooser />
     <EditableAttribute
       disabled={!editing}
       title="Base cover image URL"

--- a/app/javascript/overview/CommunityChooser.jsx
+++ b/app/javascript/overview/CommunityChooser.jsx
@@ -95,7 +95,11 @@ export const UnconnectedCommunityChooser = ({
             </CommunityMenu>
           }
         >
-          <CommunityName white={white} onClick={acceptKeyboardClick}>
+          <CommunityName
+            white={white}
+            disabled={!anyCommunitiesPresent}
+            onClick={acceptKeyboardClick}
+          >
             <Tooltip
               isDisabled={activeCommunityPresent}
               content="Your active community is not discussing this case"
@@ -160,10 +164,10 @@ const CommunityName = styled.a.attrs({
   &:focus,
   &:hover {
     outline: none;
-    color: white !important;
+    color: ${({ disabled }) => (disabled ? 'inhert' : 'white !important')};
 
     & > span {
-      text-decoration: underline;
+      text-decoration: ${({ disabled }) => (disabled ? '' : 'underline')};
     }
   }
 `

--- a/app/javascript/overview/CommunityChooser.jsx
+++ b/app/javascript/overview/CommunityChooser.jsx
@@ -7,6 +7,10 @@ import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
+import { Popover, Menu, MenuItem, Position } from '@blueprintjs/core'
+
+import { acceptKeyboardClick } from 'shared/keyboard'
+
 import type { State, Community } from 'redux/state'
 
 type OwnProps = { rounded: boolean }
@@ -25,9 +29,38 @@ export const UnconnectedCommunityChooser = ({
 }: Props) =>
   <Bar empty={!activeCommunity} rounded={rounded}>
     {activeCommunity &&
-      <CommunityName>
-        {activeCommunity.name}
-      </CommunityName>}
+      <Popover
+        position={rounded ? Position.BOTTOM_LEFT : Position.BOTTOM}
+        content={
+          <CommunityMenu>
+            <li className="pt-menu-header">
+              <h6>Choose a community</h6>
+            </li>
+            <Instructions>
+              You’ll see the discussion taking place in the community you
+              choose.
+            </Instructions>
+
+            <MenuItem
+              iconName="globe"
+              className="pt-active pt-intent-primary"
+              text="Global Community"
+              onClick={() => {}}
+              onKeyPress={acceptKeyboardClick}
+            />
+            <MenuItem
+              iconName="social-media"
+              text="Invited Community"
+              onClick={() => {}}
+              onKeyPress={acceptKeyboardClick}
+            />
+          </CommunityMenu>
+        }
+      >
+        <CommunityName onClick={acceptKeyboardClick}>
+          <span>{activeCommunity.name}</span> ▾
+        </CommunityName>
+      </Popover>}
   </Bar>
 
 export default connect(mapStateToProps)(UnconnectedCommunityChooser)
@@ -45,8 +78,32 @@ const Bar = styled.div`
   border-radius: ${({ rounded }) => (rounded ? '0 0 2pt 2pt' : '0')};
 `
 
-const CommunityName = styled.span`
+const CommunityMenu = styled(Menu)`
+  width: 16em;
+`
+
+const Instructions = styled.li`
+  margin: 5px;
+  padding-left: 2px;
+  font-style: italic;
+  line-height: 1.2;
+`
+
+const CommunityName = styled.a.attrs({
+  tabIndex: '0',
+  href: '#',
+})`
   font-weight: bold;
-  color: #d4c5ff;
+  color: #d4c5ff !important;
   display: inline-block;
+
+  &:focus,
+  &:hover {
+    outline: none;
+    color: white !important;
+
+    & > span {
+      text-decoration: underline;
+    }
+  }
 `

--- a/app/javascript/overview/CommunityChooser.jsx
+++ b/app/javascript/overview/CommunityChooser.jsx
@@ -31,7 +31,7 @@ function mapStateToProps (
 
 type Props = {
   activeCommunity: ?Community,
-  communities: Community[],
+  communities: ?(Community[]),
   rounded: boolean,
   white: boolean,
   disabled: boolean,
@@ -65,7 +65,7 @@ export const UnconnectedCommunityChooser = ({
               You’ll see the discussion taking place in the community you
               choose.
             </Instructions>
-            {communities.map(c =>
+            {(communities || []).map(c =>
               <MenuItem
                 key={c.id || 'null'}
                 iconName={c.global ? 'globe' : 'social-media'}

--- a/app/javascript/overview/CommunityChooser.jsx
+++ b/app/javascript/overview/CommunityChooser.jsx
@@ -1,5 +1,5 @@
 /**
- * @providesModule GroupChooser
+ * @providesModule CommunityChooser
  * @flow
  */
 
@@ -7,24 +7,27 @@ import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
-import type { State, Group } from 'redux/state'
+import type { State, Community } from 'redux/state'
 
 type OwnProps = { rounded: boolean }
 function mapStateToProps ({ caseData }: State, { rounded }: OwnProps) {
   const { reader } = caseData
-  return { rounded, activeGroup: reader && reader.activeGroup }
+  return { rounded, activeCommunity: reader && reader.activeCommunity }
 }
 
-type Props = { activeGroup: ?Group, rounded: boolean }
-export const UnconnectedGroupChooser = ({ activeGroup, rounded }: Props) =>
-  <Bar empty={!activeGroup} rounded={rounded}>
-    {activeGroup &&
-      <GroupName>
-        {activeGroup.name}
-      </GroupName>}
+type Props = { activeCommunity: ?Community, rounded: boolean }
+export const UnconnectedCommunityChooser = ({
+  activeCommunity,
+  rounded,
+}: Props) =>
+  <Bar empty={!activeCommunity} rounded={rounded}>
+    {activeCommunity &&
+      <CommunityName>
+        {activeCommunity.name}
+      </CommunityName>}
   </Bar>
 
-export default connect(mapStateToProps)(UnconnectedGroupChooser)
+export default connect(mapStateToProps)(UnconnectedCommunityChooser)
 
 const Bar = styled.div`
   background-color: #373566;
@@ -39,7 +42,7 @@ const Bar = styled.div`
   border-radius: ${({ rounded }) => (rounded ? '0 0 2pt 2pt' : '0')};
 `
 
-const GroupName = styled.span`
+const CommunityName = styled.span`
   font-weight: bold;
   color: #d4c5ff;
   display: inline-block;

--- a/app/javascript/overview/CommunityChooser.jsx
+++ b/app/javascript/overview/CommunityChooser.jsx
@@ -7,20 +7,22 @@ import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
-import { Popover, Menu, MenuItem, Position } from '@blueprintjs/core'
+import { Popover, Menu, MenuItem, Position, Icon } from '@blueprintjs/core'
 
 import { acceptKeyboardClick } from 'shared/keyboard'
 import { updateActiveCommunity } from 'redux/actions'
 
 import type { State, Community } from 'redux/state'
 
-type OwnProps = { rounded: boolean }
+type OwnProps = { rounded: boolean, white: boolean, disabled: boolean }
 function mapStateToProps (
   { caseData, communities }: State,
-  { rounded }: OwnProps
+  { rounded, white, disabled }: OwnProps
 ) {
   return {
     rounded,
+    white,
+    disabled,
     communities,
     caseSlug: caseData.slug,
     activeCommunity: communities.find(community => community.active),
@@ -31,6 +33,8 @@ type Props = {
   activeCommunity: ?Community,
   communities: Community[],
   rounded: boolean,
+  white: boolean,
+  disabled: boolean,
   caseSlug?: string,
   updateActiveCommunity?: typeof updateActiveCommunity,
 }
@@ -38,10 +42,17 @@ export const UnconnectedCommunityChooser = ({
   activeCommunity,
   communities,
   rounded,
+  white,
+  disabled,
   caseSlug,
   updateActiveCommunity,
 }: Props) =>
-  <Bar empty={!activeCommunity} rounded={rounded}>
+  <Bar
+    empty={!activeCommunity}
+    rounded={rounded}
+    white={white}
+    disabled={disabled}
+  >
     {activeCommunity &&
       <Popover
         position={rounded ? Position.BOTTOM_LEFT : Position.BOTTOM}
@@ -71,8 +82,16 @@ export const UnconnectedCommunityChooser = ({
           </CommunityMenu>
         }
       >
-        <CommunityName onClick={acceptKeyboardClick}>
-          <span>{activeCommunity.name}</span> ▾
+        <CommunityName white={white} onClick={acceptKeyboardClick}>
+          <span>
+            <span
+              className={`pt-icon pt-icon-${activeCommunity.global
+                ? 'globe'
+                : 'social-media'}`}
+            />&#8196;
+            {activeCommunity.name}
+          </span>
+          {disabled ? '' : ' ▾'}
         </CommunityName>
       </Popover>}
   </Bar>
@@ -82,7 +101,7 @@ export default connect(mapStateToProps, { updateActiveCommunity })(
 )
 
 const Bar = styled.div`
-  background-color: #373566;
+  background-color: ${({ white }) => (white ? '#EBEAE4' : '#373566')};
   font-size: 10pt;
   line-height: 1.2;
   text-align: center;
@@ -91,7 +110,9 @@ const Bar = styled.div`
   border-bottom-width: 4px;
   border-bottom-style: solid;
   border-bottom-color: ${({ empty }) => (empty ? '#6acb72' : '#8764ea')};
-  border-radius: ${({ rounded }) => (rounded ? '0 0 2pt 2pt' : '0')};
+  border-radius: ${({ rounded, white }) =>
+    white ? '2pt' : rounded ? '0 0 2pt 2pt' : '0'};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'all')};
 `
 
 const CommunityMenu = styled(Menu)`
@@ -110,8 +131,9 @@ const CommunityName = styled.a.attrs({
   href: '#',
 })`
   font-weight: bold;
-  color: #d4c5ff !important;
   display: inline-block;
+
+  color: ${({ white }) => (white ? '#373566' : '#d4c5ff')} !important;
 
   &:focus,
   &:hover {

--- a/app/javascript/overview/CommunityChooser.jsx
+++ b/app/javascript/overview/CommunityChooser.jsx
@@ -10,14 +10,19 @@ import styled from 'styled-components'
 import { Popover, Menu, MenuItem, Position } from '@blueprintjs/core'
 
 import { acceptKeyboardClick } from 'shared/keyboard'
+import { updateActiveCommunity } from 'redux/actions'
 
 import type { State, Community } from 'redux/state'
 
 type OwnProps = { rounded: boolean }
-function mapStateToProps ({ communities }: State, { rounded }: OwnProps) {
+function mapStateToProps (
+  { caseData, communities }: State,
+  { rounded }: OwnProps
+) {
   return {
     rounded,
     communities,
+    caseSlug: caseData.slug,
     activeCommunity: communities.find(community => community.active),
   }
 }
@@ -26,11 +31,15 @@ type Props = {
   activeCommunity: ?Community,
   communities: Community[],
   rounded: boolean,
+  caseSlug?: string,
+  updateActiveCommunity?: typeof updateActiveCommunity,
 }
 export const UnconnectedCommunityChooser = ({
   activeCommunity,
   communities,
   rounded,
+  caseSlug,
+  updateActiveCommunity,
 }: Props) =>
   <Bar empty={!activeCommunity} rounded={rounded}>
     {activeCommunity &&
@@ -51,7 +60,11 @@ export const UnconnectedCommunityChooser = ({
                 iconName={c.global ? 'globe' : 'social-media'}
                 className={c.active ? 'pt-active pt-intent-primary' : ''}
                 text={c.name}
-                onClick={() => {}}
+                onClick={() => {
+                  updateActiveCommunity &&
+                    caseSlug &&
+                    updateActiveCommunity(caseSlug, c.id)
+                }}
                 onKeyPress={acceptKeyboardClick}
               />
             )}
@@ -64,7 +77,9 @@ export const UnconnectedCommunityChooser = ({
       </Popover>}
   </Bar>
 
-export default connect(mapStateToProps)(UnconnectedCommunityChooser)
+export default connect(mapStateToProps, { updateActiveCommunity })(
+  UnconnectedCommunityChooser
+)
 
 const Bar = styled.div`
   background-color: #373566;

--- a/app/javascript/overview/CommunityChooser.jsx
+++ b/app/javascript/overview/CommunityChooser.jsx
@@ -12,7 +12,10 @@ import type { State, Community } from 'redux/state'
 type OwnProps = { rounded: boolean }
 function mapStateToProps ({ caseData }: State, { rounded }: OwnProps) {
   const { reader } = caseData
-  return { rounded, activeCommunity: reader && reader.activeCommunity }
+  return {
+    rounded,
+    activeCommunity: reader && reader.enrollment && reader.activeCommunity,
+  }
 }
 
 type Props = { activeCommunity: ?Community, rounded: boolean }

--- a/app/javascript/overview/CommunityChooser.jsx
+++ b/app/javascript/overview/CommunityChooser.jsx
@@ -14,17 +14,22 @@ import { acceptKeyboardClick } from 'shared/keyboard'
 import type { State, Community } from 'redux/state'
 
 type OwnProps = { rounded: boolean }
-function mapStateToProps ({ caseData }: State, { rounded }: OwnProps) {
-  const { reader } = caseData
+function mapStateToProps ({ communities }: State, { rounded }: OwnProps) {
   return {
     rounded,
-    activeCommunity: reader && reader.enrollment && reader.activeCommunity,
+    communities,
+    activeCommunity: communities.find(community => community.active),
   }
 }
 
-type Props = { activeCommunity: ?Community, rounded: boolean }
+type Props = {
+  activeCommunity: ?Community,
+  communities: Community[],
+  rounded: boolean,
+}
 export const UnconnectedCommunityChooser = ({
   activeCommunity,
+  communities,
   rounded,
 }: Props) =>
   <Bar empty={!activeCommunity} rounded={rounded}>
@@ -40,20 +45,16 @@ export const UnconnectedCommunityChooser = ({
               You’ll see the discussion taking place in the community you
               choose.
             </Instructions>
-
-            <MenuItem
-              iconName="globe"
-              className="pt-active pt-intent-primary"
-              text="Global Community"
-              onClick={() => {}}
-              onKeyPress={acceptKeyboardClick}
-            />
-            <MenuItem
-              iconName="social-media"
-              text="Invited Community"
-              onClick={() => {}}
-              onKeyPress={acceptKeyboardClick}
-            />
+            {communities.map(c =>
+              <MenuItem
+                key={c.id || 'null'}
+                iconName={c.global ? 'globe' : 'social-media'}
+                className={c.active ? 'pt-active pt-intent-primary' : ''}
+                text={c.name}
+                onClick={() => {}}
+                onKeyPress={acceptKeyboardClick}
+              />
+            )}
           </CommunityMenu>
         }
       >

--- a/app/javascript/packs/billboard.entry.jsx
+++ b/app/javascript/packs/billboard.entry.jsx
@@ -35,7 +35,12 @@ if (container != null) {
   ReactDOM.render(
     <Column>
       <UnconnectedBillboardTitle updateCase={() => {}} {...caseData} />
-      <UnconnectedCommunityChooser rounded activeCommunity={groupData} />
+      <UnconnectedCommunityChooser
+        rounded
+        disabled
+        activeCommunity={groupData}
+        communities={[{ groupData }]}
+      />
 
       <form action="/enrollments" method="POST">
         <input type="hidden" name="deployment_key" value={deploymentKey} />

--- a/app/javascript/packs/billboard.entry.jsx
+++ b/app/javascript/packs/billboard.entry.jsx
@@ -7,7 +7,7 @@ import ReactDOM from 'react-dom'
 import styled from 'styled-components'
 
 import { UnconnectedBillboardTitle } from 'overview/BillboardTitle'
-import { UnconnectedGroupChooser } from 'overview/GroupChooser'
+import { UnconnectedCommunityChooser } from 'overview/CommunityChooser'
 
 const container = document.getElementById('billboard-app')
 
@@ -35,7 +35,7 @@ if (container != null) {
   ReactDOM.render(
     <Column>
       <UnconnectedBillboardTitle updateCase={() => {}} {...caseData} />
-      <UnconnectedGroupChooser rounded activeGroup={groupData} />
+      <UnconnectedCommunityChooser rounded activeCommunity={groupData} />
 
       <form action="/enrollments" method="POST">
         <input type="hidden" name="deployment_key" value={deploymentKey} />

--- a/app/javascript/packs/case.entry.jsx
+++ b/app/javascript/packs/case.entry.jsx
@@ -9,6 +9,7 @@ import { AppContainer } from 'react-hot-loader'
 
 import { createStore, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
+import { enableBatching } from 'redux-batched-actions'
 import thunk from 'redux-thunk'
 
 import { FocusStyleManager } from '@blueprintjs/core'
@@ -27,7 +28,7 @@ import messages from '../../../config/locales/react.json' // eslint-disable-line
 
 FocusStyleManager.onlyShowFocusOnTabs()
 
-const store = createStore(reducer, applyMiddleware(thunk))
+const store = createStore(enableBatching(reducer), applyMiddleware(thunk))
 
 if (!global.Intl) {
   global.Intl = require('intl')

--- a/app/javascript/quiz/Quiz.jsx
+++ b/app/javascript/quiz/Quiz.jsx
@@ -40,7 +40,7 @@ type QuizState = { [questionId: string]: string }
 type QuizDelegateProps = {
   canSubmit: boolean,
   onChange: (questionId: string, e: SyntheticInputEvent) => void,
-  onSubmit: (e: SyntheticMouseEvent) => void,
+  onSubmit: (e: SyntheticEvent) => void,
 }
 
 export type QuizProviderProps = QuizDelegateProps & QuizProps & QuizState

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -23,6 +23,7 @@ import type {
   CommentsState,
   CommentThread,
   CommentThreadsState,
+  Community,
   Edgenote,
   QuizNecessity,
   Notification,
@@ -65,6 +66,7 @@ export type Action =
   | SetCardsAction
   | SetCommentsByIdAction
   | SetCommentThreadsByIdAction
+  | SetCommunitiesAction
 
 type GetState = () => State
 type PromiseAction = Promise<Action>
@@ -480,6 +482,23 @@ export function applySelection (
   selectionState: SelectionState
 ): ApplySelectionAction {
   return { type: 'APPLY_SELECTION', cardId, selectionState }
+}
+
+// COMMUNITY
+//
+export function fetchCommunities (slug: string): ThunkAction {
+  return async (dispatch: Dispatch) => {
+    const { communities } = await Orchard.harvest(`cases/${slug}/communities`)
+    dispatch(setCommunities(communities))
+  }
+}
+
+export type SetCommunitiesAction = {
+  type: 'SET_COMMUNITIES',
+  communities: Community[],
+}
+export function setCommunities (communities: Community[]): SetCommunitiesAction {
+  return { type: 'SET_COMMUNITIES', communities }
 }
 
 // COMMENT THREAD

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -242,6 +242,7 @@ export function enrollReader (readerId: string, caseSlug: string): ThunkAction {
       `admin/cases/${caseSlug}/readers/${readerId}/enrollments/upsert`
     )
     dispatch(setReaderEnrollment(!!enrollment))
+    dispatch(fetchCommentThreads(caseSlug))
   }
 }
 

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -246,6 +246,7 @@ export function enrollReader (readerId: string, caseSlug: string): ThunkAction {
       `admin/cases/${caseSlug}/readers/${readerId}/enrollments/upsert`
     )
     dispatch(setReaderEnrollment(!!enrollment))
+    dispatch(fetchCommunities(caseSlug))
     dispatch(fetchCommentThreads(caseSlug))
   }
 }

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -75,7 +75,7 @@ type PromiseAction = Promise<Action>
 type ThunkAction = (dispatch: Dispatch, getState: GetState) => any
 export type Dispatch = (
   action: Action | ThunkAction | PromiseAction | Array<Action>
-) => void
+) => Promise<any>
 
 // API
 
@@ -799,13 +799,26 @@ export type HandleNotificationAction = {
 }
 export function handleNotification (notification: Notification): ThunkAction {
   return (dispatch: Dispatch) => {
+    const {
+      message,
+      case: kase,
+      element,
+      cardId,
+      commentThreadId,
+      community,
+    } = notification
     dispatch(
       displayToast({
-        message: notification.message,
+        message,
         intent: Intent.PRIMARY,
         action: {
-          href: `/cases/${notification.case.slug}/${notification.element
-            .position}/cards/${notification.cardId}/comments/${notification.commentThreadId}`,
+          onClick: _ => {
+            dispatch(
+              updateActiveCommunity(kase.slug, community.id)
+            ).then(() => {
+              window.location = `/cases/${kase.slug}/${element.position}/cards/${cardId}/comments/${commentThreadId}`
+            })
+          },
           text: 'Read',
         },
       })

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -493,6 +493,16 @@ export function fetchCommunities (slug: string): ThunkAction {
   }
 }
 
+export function updateActiveCommunity (
+  slug: string,
+  id: string | null
+): ThunkAction {
+  return async (dispatch: Dispatch) => {
+    await Orchard.espalier(`profile`, { reader: { activeCommunityId: id }})
+    dispatch(fetchCommunities(slug))
+  }
+}
+
 export type SetCommunitiesAction = {
   type: 'SET_COMMUNITIES',
   communities: Community[],

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -2,6 +2,8 @@
  * @flow
  */
 
+import { batchActions } from 'redux-batched-actions'
+
 import { Orchard } from 'shared/orchard'
 import { convertToRaw } from 'draft-js'
 import { Intent } from '@blueprintjs/core'
@@ -500,6 +502,7 @@ export function updateActiveCommunity (
   return async (dispatch: Dispatch) => {
     await Orchard.espalier(`profile`, { reader: { activeCommunityId: id }})
     dispatch(fetchCommunities(slug))
+    dispatch(fetchCommentThreads(slug))
   }
 }
 
@@ -518,9 +521,13 @@ export function fetchCommentThreads (slug: string): ThunkAction {
     const { commentThreads, comments, cards } = await Orchard.harvest(
       `cases/${slug}/comment_threads`
     )
-    dispatch(setCommentsById(comments))
-    dispatch(setCommentThreadsById(commentThreads))
-    dispatch(setCards(cards))
+    dispatch(
+      batchActions([
+        setCommentsById(comments),
+        setCommentThreadsById(commentThreads),
+        setCards(cards),
+      ])
+    )
     dispatch(parseAllCards())
   }
 }

--- a/app/javascript/redux/reducers/cards.js
+++ b/app/javascript/redux/reducers/cards.js
@@ -84,11 +84,13 @@ function cardsById (
     case 'ADD_COMMENT_THREAD': {
       const { data } = action
       const card = state[data.cardId]
-      if (card.commentThreads.find(x => x.id === data.id)) return state
+      const commentThreads = card.commentThreads || []
+
+      if (commentThreads.find(x => x.id === data.id)) return state
 
       const newCard = {
         ...card,
-        commentThreads: [...card.commentThreads, data].sort(sortCommentThreads),
+        commentThreads: [...commentThreads, data].sort(sortCommentThreads),
       }
       return {
         ...state,
@@ -101,11 +103,10 @@ function cardsById (
 
     case 'REMOVE_COMMENT_THREAD': {
       const { cardId, threadId } = action
+      const commentThreads = state[cardId].commentThreads || []
       const newCard = {
         ...state[cardId],
-        commentThreads: state[cardId].commentThreads.filter(
-          x => x.id !== threadId
-        ),
+        commentThreads: commentThreads.filter(x => x.id !== threadId),
       }
       return {
         ...state,

--- a/app/javascript/redux/reducers/caseData.js
+++ b/app/javascript/redux/reducers/caseData.js
@@ -14,6 +14,7 @@ import type {
   AddPageAction,
   AddPodcastAction,
   AddActivityAction,
+  SetCommunitiesAction,
 } from 'redux/actions'
 
 import type { CaseDataState } from 'redux/state'
@@ -27,6 +28,7 @@ type Action =
   | AddPageAction
   | AddPodcastAction
   | AddActivityAction
+  | SetCommunitiesAction
 
 export default function caseData (
   state: CaseDataState = ({ ...window.caseData }: CaseDataState),
@@ -80,6 +82,17 @@ export default function caseData (
           ...state.caseElements.slice(0, action.position),
           ...state.caseElements.slice(action.position + 1),
         ],
+      }
+
+    case 'SET_COMMUNITIES':
+      return {
+        ...state,
+        reader: {
+          ...state.reader,
+          activeCommunity:
+            action.communities.find(x => x.active) ||
+            (state.reader && state.reader.activeCommunity),
+        },
       }
 
     default:

--- a/app/javascript/redux/reducers/commentThreadsById.js
+++ b/app/javascript/redux/reducers/commentThreadsById.js
@@ -23,7 +23,7 @@ export default function commentThreadsById (
 ): CommentThreadsState {
   switch (action.type) {
     case 'SET_COMMENT_THREADS_BY_ID':
-      return action.commentThreadsById
+      return action.commentThreadsById || {}
 
     case 'ADD_COMMENT_THREAD':
       return {

--- a/app/javascript/redux/reducers/commentThreadsById.js
+++ b/app/javascript/redux/reducers/commentThreadsById.js
@@ -5,17 +5,26 @@
 
 import type { CommentThreadsState } from 'redux/state'
 import type {
+  SetCommentThreadsByIdAction,
   AddCommentThreadAction,
   RemoveCommentThreadAction,
 } from 'redux/actions'
+
+type Action =
+  | SetCommentThreadsByIdAction
+  | AddCommentThreadAction
+  | RemoveCommentThreadAction
 
 export default function commentThreadsById (
   state: CommentThreadsState = ({
     ...window.caseData.commentThreads,
   }: CommentThreadsState),
-  action: AddCommentThreadAction | RemoveCommentThreadAction
+  action: Action
 ): CommentThreadsState {
   switch (action.type) {
+    case 'SET_COMMENT_THREADS_BY_ID':
+      return action.commentThreadsById
+
     case 'ADD_COMMENT_THREAD':
       return {
         ...state,

--- a/app/javascript/redux/reducers/commentsById.js
+++ b/app/javascript/redux/reducers/commentsById.js
@@ -4,13 +4,16 @@
  */
 
 import type { CommentsState } from 'redux/state'
-import type { AddCommentAction } from 'redux/actions'
+import type { SetCommentsByIdAction, AddCommentAction } from 'redux/actions'
 
 export default function commentsById (
   state: CommentsState = ({ ...window.caseData.comments }: CommentsState),
-  action: AddCommentAction
+  action: SetCommentsByIdAction | AddCommentAction
 ): CommentsState {
   switch (action.type) {
+    case 'SET_COMMENTS_BY_ID':
+      return action.commentsById
+
     case 'ADD_COMMENT':
       return {
         ...state,

--- a/app/javascript/redux/reducers/commentsById.js
+++ b/app/javascript/redux/reducers/commentsById.js
@@ -12,7 +12,7 @@ export default function commentsById (
 ): CommentsState {
   switch (action.type) {
     case 'SET_COMMENTS_BY_ID':
-      return action.commentsById
+      return action.commentsById || {}
 
     case 'ADD_COMMENT':
       return {

--- a/app/javascript/redux/reducers/communities.js
+++ b/app/javascript/redux/reducers/communities.js
@@ -1,0 +1,21 @@
+/**
+ * @providesModule communities
+ * @flow
+ */
+
+import type { Community } from 'redux/state'
+import type { SetCommunitiesAction } from 'redux/actions'
+
+type Action = SetCommunitiesAction
+export default function communities (
+  state: Community[] = [],
+  action: Action
+): Community[] {
+  switch (action.type) {
+    case 'SET_COMMUNITIES':
+      return action.communities
+
+    default:
+      return state
+  }
+}

--- a/app/javascript/redux/reducers/index.js
+++ b/app/javascript/redux/reducers/index.js
@@ -1,5 +1,5 @@
 /**
- * @providesModule reducer
+ * @providesModule reducers
  * @flow
  */
 
@@ -12,13 +12,14 @@ import podcastsById from './podcastsById'
 import activitiesById from './activitiesById'
 import commentThreadsById from './commentThreadsById'
 import commentsById from './commentsById'
+import communities from './communities'
 import cardsById from './cards'
 import quiz from './quiz'
 import edit from './edit'
 import statistics from './statistics'
 import ui from './ui'
 
-const reducer = combineReducers({
+const state = {
   caseData,
   edgenotesBySlug,
   pagesById,
@@ -27,10 +28,16 @@ const reducer = combineReducers({
   cardsById,
   commentThreadsById,
   commentsById,
+  communities,
   statistics,
   quiz,
   edit,
   ui,
-})
+}
+
+const reducer = combineReducers(state)
 
 export default reducer
+
+type ExtractReturnType = <V>((...*) => V) => V
+export type State = $ObjMap<typeof state, ExtractReturnType>

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -5,20 +5,7 @@
 import type { EditorState } from 'draft-js'
 
 // Redux state
-export type State = {
-  activitiesById: ActivitiesState,
-  cardsById: CardsState,
-  caseData: CaseDataState,
-  commentThreadsById: CommentThreadsState,
-  commentsById: CommentsState,
-  edgenotesBySlug: EdgenotesState,
-  edit: EditState,
-  pagesById: PagesState,
-  podcastsById: PodcastsState,
-  quiz: QuizState,
-  statistics: StatisticsState,
-  ui: UIState,
-}
+export type { State } from 'redux/reducers'
 
 export type ActivitiesState = {
   [activityId: string]: Activity,
@@ -203,6 +190,8 @@ export type Edgenote = {
 export type Community = {
   id: string | null,
   name: string,
+  active: boolean,
+  global: boolean,
 }
 
 export type ReplyToThreadNotification = {

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -135,7 +135,7 @@ export type Byline = {
 export type Card = {
   commentThreads: ?(CommentThread[]),
   content: string,
-  editorState: EditorState,
+  editorState: ?EditorState,
   id: string,
   position: number,
   rawContent: string,

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -201,6 +201,10 @@ export type ReplyToThreadNotification = {
     name: string,
     initials: string,
   },
+  community: {
+    id: string,
+    name: string,
+  },
   case: {
     slug: string,
     kicker: string,

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -133,7 +133,7 @@ export type Byline = {
 }
 
 export type Card = {
-  commentThreads: CommentThread[],
+  commentThreads: ?(CommentThread[]),
   content: string,
   editorState: EditorState,
   id: string,
@@ -169,6 +169,7 @@ export type CommentThread = {
   blockIndex: number,
   cardId: string,
   commentIds: number[],
+  commentsCount: number,
   id: string,
   length: number,
   originalHighlightText: string,

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -200,7 +200,8 @@ export type Edgenote = {
   youtubeSlug: string,
 }
 
-export type Group = {
+export type Community = {
+  id: string | null,
   name: string,
 }
 
@@ -269,7 +270,7 @@ export type Question = {
 }
 
 export type Reader = {
-  activeGroup: ?Group,
+  activeCommunity: ?Community,
   canUpdateCase: boolean,
   email: string,
   enrollment: ?{

--- a/app/jobs/comment_broadcast_job.rb
+++ b/app/jobs/comment_broadcast_job.rb
@@ -4,8 +4,8 @@ class CommentBroadcastJob < ActiveJob::Base
   queue_as :default
 
   def perform(comment)
-    ActionCable.server.broadcast 'forum_channel',
-                                 comment: render_comment(comment)
+    ForumChannel.broadcast_to comment.forum,
+                              comment: render_comment(comment)
   end
 
   private

--- a/app/jobs/comment_thread_broadcast_job.rb
+++ b/app/jobs/comment_thread_broadcast_job.rb
@@ -4,9 +4,8 @@ class CommentThreadBroadcastJob < ActiveJob::Base
   queue_as :default
 
   def perform(comment_thread)
-    ActionCable.server
-               .broadcast 'forum_channel',
-                          comment_thread: render_comment_thread(comment_thread)
+    ForumChannel.broadcast_to comment_thread.forum,
+                              comment_thread: render_comment_thread(comment_thread)
   end
 
   private

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -19,6 +19,7 @@ class Case < ApplicationRecord
   has_many :comments, through: :comment_threads
   has_many :edgenotes, dependent: :destroy
   has_many :enrollments, dependent: :destroy
+  has_many :forums, dependent: :destroy
   has_many :pages, dependent: :destroy
   has_many :podcasts, dependent: :destroy
   has_many :readers, through: :enrollments
@@ -31,11 +32,17 @@ class Case < ApplicationRecord
   validates_format_of :slug, with: /\A[a-z0-9-]+\Z/
   validates :publication_date, presence: true, if: :published?
 
+  after_create :create_forum_for_global_community
+
   def <=>(other)
     return published ? 1 : -1 if published ^ other.try(:published)
     return publication_date.nil? ? -1 : 1 if publication_date.nil? ||
                                              other.publication_date.nil?
     publication_date <=> other.publication_date
+  end
+
+  def create_forum_for_global_community
+    Forum.create case: self
   end
 
   def to_param

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -63,10 +63,10 @@ class Case < ApplicationRecord
   end
 
   def comment_threads
-    cards.flat_map(&:comment_threads).uniq
+    CommentThread.where(card: cards)
   end
 
   def comments
-    comment_threads.flat_map(&:comments)
+    Comment.where(comment_thread: comment_threads)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,6 +15,8 @@ class Comment < ApplicationRecord
   after_create_commit { CommentThreadBroadcastJob.perform_later comment_thread }
   after_create_commit :send_notifications_of_reply
 
+  delegate :forum, to: :comment_thread
+
   def timestamp
     I18n.l created_at.in_time_zone('America/Detroit'), format: :long
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,7 +2,7 @@
 
 class Comment < ApplicationRecord
   belongs_to :reader
-  belongs_to :comment_thread
+  belongs_to :comment_thread, counter_cache: true
 
   include Mobility
   translates :content, fallbacks: true

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -4,7 +4,7 @@ class CommentThread < ApplicationRecord
   include Authority::Abilities
 
   belongs_to :reader
-  belongs_to :group
+  belongs_to :forum
   belongs_to :card
   has_many :comments, dependent: :restrict_with_error
 

--- a/app/models/comment_thread.rb
+++ b/app/models/comment_thread.rb
@@ -12,7 +12,10 @@ class CommentThread < ApplicationRecord
     comments.map(&:reader).uniq
   end
 
-  def visible_to_reader?(r)
-    locale == I18n.locale.to_s && (!comments.empty? || reader == r)
+  def self.visible_to_reader?(r)
+    where(locale: I18n.locale.to_s)
+      .where('comment_threads.comments_count > 0 OR
+      comment_threads.reader_id = ?',
+             r.id)
   end
 end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Community < ApplicationRecord
+  belongs_to :group
+  has_one :forum
+  has_and_belongs_to_many :readers
+
+  include Mobility
+  translates :name
+end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -2,11 +2,19 @@
 
 class Community < ApplicationRecord
   belongs_to :group
-  has_one :forum
-  has_and_belongs_to_many :readers
+  has_many :invitiations
+  has_many :forums # One forum for each case the community is discussing
 
   include Mobility
   translates :name
 
   delegate :comment_threads, to: :forum
+
+  def self.active_for_case(case_id)
+    joins(:forums).where(forums: { case_id: case_id })
+  end
+
+  def global?
+    group.nil?
+  end
 end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -7,4 +7,6 @@ class Community < ApplicationRecord
 
   include Mobility
   translates :name
+
+  delegate :comment_threads, to: :forum
 end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -2,7 +2,7 @@
 
 class Community < ApplicationRecord
   belongs_to :group
-  has_many :invitiations
+  has_many :invitations
   has_many :forums # One forum for each case the community is discussing
 
   include Mobility

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -10,6 +10,12 @@ class Deployment < ApplicationRecord
 
   validates :quiz, presence: true, if: -> { answers_needed.positive? }
 
+  after_create :create_forum
+
+  def create_forum
+    group.community.forums.create case: self.case
+  end
+
   def pretest_assigned?
     answers_needed >= 2
   end

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -4,4 +4,8 @@ class Forum < ApplicationRecord
   belongs_to :case
   belongs_to :community
   has_many :comment_threads
+
+  def community
+    super || GlobalCommunity.instance
+  end
 end

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -1,0 +1,4 @@
+class Forum < ApplicationRecord
+  belongs_to :case
+  belongs_to :community
+end

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -3,4 +3,5 @@
 class Forum < ApplicationRecord
   belongs_to :case
   belongs_to :community
+  has_many :comment_threads
 end

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Forum < ApplicationRecord
   belongs_to :case
   belongs_to :community

--- a/app/models/global_community.rb
+++ b/app/models/global_community.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Null object pattern for Community
+class GlobalCommunity
+  include Singleton
+
+  def forums
+    Forum.where community_id: nil
+  end
+end

--- a/app/models/global_community.rb
+++ b/app/models/global_community.rb
@@ -4,6 +4,14 @@
 class GlobalCommunity
   include Singleton
 
+  def id
+    nil
+  end
+
+  def name
+    I18n.t 'activerecord.models.global_community'
+  end
+
   def forums
     Forum.where community_id: nil
   end

--- a/app/models/global_community.rb
+++ b/app/models/global_community.rb
@@ -4,12 +4,20 @@
 class GlobalCommunity
   include Singleton
 
+  def to_partial_path
+    'communities/community'
+  end
+
   def id
     nil
   end
 
   def name
     I18n.t 'activerecord.models.global_community'
+  end
+
+  def global?
+    true
   end
 
   def forums

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,11 +12,17 @@ class Group < ApplicationRecord
 
   validates :context_id, uniqueness: true, if: -> () { context_id.present? }
 
+  after_create :create_associated_community
+
   def self.upsert(context_id:, name:)
     group = find_or_initialize_by context_id: context_id
     group.name = name
     group.save! if group.changed?
     group
+  end
+
+  def create_associated_community
+    create_community(name: name)
   end
 
   def deployment_for_case(kase)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,9 +2,9 @@
 
 # Mock public API in GlobalGroup
 class Group < ApplicationRecord
-  has_many :comment_threads, dependent: :destroy
   has_many :group_memberships, dependent: :destroy
   has_many :readers, through: :group_memberships
+  has_one :community
   has_many :deployments, dependent: :destroy
 
   include Mobility

--- a/app/models/group_membership.rb
+++ b/app/models/group_membership.rb
@@ -3,4 +3,10 @@
 class GroupMembership < ApplicationRecord
   belongs_to :reader
   belongs_to :group
+
+  after_create :set_readers_active_community
+
+  def set_readers_active_community
+    reader.update active_community_id: group.community.id
+  end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Invitation < ApplicationRecord
+  belongs_to :reader
+  belongs_to :community
+
+  belongs_to :inviter, class_name: 'Reader'
+end

--- a/app/models/reader.rb
+++ b/app/models/reader.rb
@@ -68,6 +68,11 @@ class Reader < ApplicationRecord
     end
   end
 
+  def active_community
+    return GlobalCommunity.instance if active_community_id.nil?
+    Community.find(active_community_id)
+  end
+
   def communities
     invited_communities | group_communities | [GlobalCommunity.instance]
   end

--- a/app/models/reader.rb
+++ b/app/models/reader.rb
@@ -22,12 +22,10 @@ class Reader < ApplicationRecord
   has_many :quizzes, through: :answers
   has_many :answers, dependent: :destroy
 
-  has_many :invited_communities, -> { includes(:forum) },
-           through: :invitations, source: :community
+  has_many :invited_communities, through: :invitations, source: :community
   has_many :invitations, dependent: :destroy
 
-  has_many :group_communities, -> { includes(:forum) },
-           through: :groups, source: :community
+  has_many :group_communities, through: :groups, source: :community
   has_many :comment_threads, dependent: :nullify
   has_many :comments, dependent: :nullify
 
@@ -74,7 +72,7 @@ class Reader < ApplicationRecord
   end
 
   def communities
-    invited_communities | group_communities | [GlobalCommunity.instance]
+    Community.where id: (invited_communities | group_communities)
   end
 
   def ensure_authentication_token

--- a/app/services/linker_service.rb
+++ b/app/services/linker_service.rb
@@ -41,6 +41,7 @@ class LinkerService
   class LTIStrategy
     def initialize(launch_params)
       @launch_params = launch_params
+      ensure_deployment_exists
     end
 
     def reader
@@ -73,6 +74,11 @@ class LinkerService
       @authentication_strategy ||= AuthenticationStrategy
                                    .find_by provider: 'lti',
                                             uid: @launch_params[:user_id]
+    end
+
+    def ensure_deployment_exists
+      return unless group.deployments.exists? case: kase
+      group.deployments.create case: kase
     end
   end
 

--- a/app/views/cards/_card.json.jbuilder
+++ b/app/views/cards/_card.json.jbuilder
@@ -1,7 +1,11 @@
-json.key_format! camelize: :lower
-json.extract! card, *%i(id position solid raw_content)
-json.content card.content || ""
+# frozen_string_literal: true
 
-json.comment_threads card.comment_threads.select { |x| x.visible_to_reader? current_reader } do |comment_thread|
-  json.partial! comment_thread
+json.key_format! camelize: :lower
+json.extract! card, :id, :position, :solid, :raw_content
+json.content card.content || ''
+
+if @comment_threads
+  json.comment_threads @comment_threads.where(card: card) do |comment_thread|
+    json.partial! comment_thread
+  end
 end

--- a/app/views/cards/_card.json.jbuilder
+++ b/app/views/cards/_card.json.jbuilder
@@ -5,7 +5,7 @@ json.extract! card, :id, :position, :solid, :raw_content
 json.content card.content || ''
 
 if @comment_threads
-  json.comment_threads @comment_threads.where(card: card) do |comment_thread|
+  json.comment_threads threads_for_card(@comment_threads, card.id) do |comment_thread|
     json.partial! comment_thread
   end
 end

--- a/app/views/cases/_show.json.jbuilder
+++ b/app/views/cases/_show.json.jbuilder
@@ -17,10 +17,6 @@ if reader_signed_in?
     json.partial! current_reader
     json.can_update_case current_reader.can_update? c
     json.enrollment @enrollment
-
-    json.active_community do
-      json.extract!(current_reader.active_community, :id, :name)
-    end
   end
 
   json.quiz do

--- a/app/views/cases/_show.json.jbuilder
+++ b/app/views/cases/_show.json.jbuilder
@@ -5,13 +5,6 @@ json.key_format! camelize: :lower
 json.partial! 'case', c: c
 
 if reader_signed_in?
-  if c.commentable
-    by_id json,
-          comment_threads: c.comment_threads
-                            .select { |x| x.visible_to_reader? current_reader },
-          comments: c.comments
-  end
-
   if current_user.has_cached_role?(:editor)
     json.statistics do
       json.keep true
@@ -24,11 +17,6 @@ if reader_signed_in?
     json.partial! current_reader
     json.can_update_case current_reader.can_update? c
     json.enrollment @enrollment
-    if @group.active?
-      json.active_group do
-        json.extract! @group, :id, :name
-      end
-    end
   end
 
   json.quiz do

--- a/app/views/cases/_show.json.jbuilder
+++ b/app/views/cases/_show.json.jbuilder
@@ -17,6 +17,9 @@ if reader_signed_in?
     json.partial! current_reader
     json.can_update_case current_reader.can_update? c
     json.enrollment @enrollment
+    json.active_community do
+      json.partial! current_reader.active_community
+    end
   end
 
   json.quiz do

--- a/app/views/cases/_show.json.jbuilder
+++ b/app/views/cases/_show.json.jbuilder
@@ -17,6 +17,10 @@ if reader_signed_in?
     json.partial! current_reader
     json.can_update_case current_reader.can_update? c
     json.enrollment @enrollment
+
+    json.active_community do
+      json.extract!(current_reader.active_community, :id, :name)
+    end
   end
 
   json.quiz do

--- a/app/views/comment_threads/_comment_thread.json.jbuilder
+++ b/app/views/comment_threads/_comment_thread.json.jbuilder
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 json.key_format! camelize: :lower
-json.(comment_thread, *%i(id card_id block_index start length
-                          original_highlight_text reader_id))
+json.call(comment_thread, :id, :card_id, :block_index, :start, :length,
+          :original_highlight_text, :reader_id, :comments_count)
 json.comment_ids comment_thread.comments.map(&:id)

--- a/app/views/comment_threads/index.json.jbuilder
+++ b/app/views/comment_threads/index.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+by_id json,
+      comment_threads: @comment_threads,
+      comments: @comment_threads.flat_map(&:comments),
+      cards: @case.cards

--- a/app/views/comment_threads/index.json.jbuilder
+++ b/app/views/comment_threads/index.json.jbuilder
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+json.key_format! camelize: :lower
+
 by_id json,
       comment_threads: @comment_threads,
       comments: @comment_threads.flat_map(&:comments),

--- a/app/views/communities/_community.json.jbuilder
+++ b/app/views/communities/_community.json.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.key_format! camelize: :lower
+
+json.extract! community, :id, :name
+json.active community == current_reader.active_community
+json.global community.global?

--- a/app/views/communities/index.json.jbuilder
+++ b/app/views/communities/index.json.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.key_format! camelize: :lower
+
+json.communities do
+  json.array! @communities, partial: 'communities/community', as: 'community'
+end

--- a/app/views/readers/show.json.jbuilder
+++ b/app/views/readers/show.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.key_format! camelize: :lower
+json.extract! @reader, :id, :name, :email, :initials, :image_url,
+              :active_community_id

--- a/app/views/reply_notifications/_reply_notification.json.jbuilder
+++ b/app/views/reply_notifications/_reply_notification.json.jbuilder
@@ -3,6 +3,9 @@
 json.key_format! camelize: :lower
 
 json.extract! reply_notification, :id, :message, :card_id, :comment_thread_id
+json.community do
+  json.extract! reply_notification.comment_thread.forum.community, :id, :name
+end
 json.notifier do
   json.extract! reply_notification.notifier, :id, :name, :initials
 end

--- a/config/locales/translations/en.yml
+++ b/config/locales/translations/en.yml
@@ -7,6 +7,7 @@ en:
       comment_thread: Comment thread  #g
       edgenote: Edgenote  #g
       enrollment: Enrollment  #g
+      global_community: Global Community
       group: Group  #g
       group_membership: Group membership  #g
       podcast: Podcast  #g

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
         resource :statistics, only: %i[show]
       end
       resources :comment_threads, only: %i[index]
+      resources :communities, only: %i[index]
 
       get '*react_router_location', to: 'cases#show'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get '/read/497/(*x)', to: redirect('/cases/mi-wolves')
 
   scope '(:locale)', locale: locale_regex do
-    resources :comment_threads, only: [] do
+    resources :comment_threads, only: %i[show] do
       resources :comments, shallow: true
     end
     resources :cases, except: %i[index create edit], param: :slug do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get '/read/497/(*x)', to: redirect('/cases/mi-wolves')
 
   scope '(:locale)', locale: locale_regex do
-    resources :comment_threads do
+    resources :comment_threads, only: [] do
       resources :comments, shallow: true
     end
     resources :cases, except: %i[index create edit], param: :slug do
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       resources :edgenotes, shallow: true, param: :slug do
         resource :statistics, only: %i[show]
       end
+      resources :comment_threads, only: %i[index]
 
       get '*react_router_location', to: 'cases#show'
     end

--- a/db/migrate/20170808143515_create_communities.rb
+++ b/db/migrate/20170808143515_create_communities.rb
@@ -1,0 +1,10 @@
+class CreateCommunities < ActiveRecord::Migration[5.0]
+  def change
+    create_table :communities do |t|
+      t.jsonb :name
+      t.references :group, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170808143515_create_communities.rb
+++ b/db/migrate/20170808143515_create_communities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCommunities < ActiveRecord::Migration[5.0]
   def change
     create_table :communities do |t|

--- a/db/migrate/20170808143606_create_forums.rb
+++ b/db/migrate/20170808143606_create_forums.rb
@@ -1,0 +1,10 @@
+class CreateForums < ActiveRecord::Migration[5.0]
+  def change
+    create_table :forums do |t|
+      t.references :case, foreign_key: true
+      t.references :community, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170808143606_create_forums.rb
+++ b/db/migrate/20170808143606_create_forums.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateForums < ActiveRecord::Migration[5.0]
   def change
     create_table :forums do |t|
@@ -5,6 +7,18 @@ class CreateForums < ActiveRecord::Migration[5.0]
       t.references :community, foreign_key: true
 
       t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        Group.find_each do |g|
+          g.create_community name: g.name
+          g.deployments.each do |d|
+            g.community.forums.create case: d.case
+          end
+        end
+      end
+      dir.down {}
     end
   end
 end

--- a/db/migrate/20170808150850_change_comment_threads_scope_to_forum.rb
+++ b/db/migrate/20170808150850_change_comment_threads_scope_to_forum.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeCommentThreadsScopeToForum < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :comment_threads, :forum, foreign_key: true
+    remove_reference :comment_threads, :group, foreign_key: true
+  end
+end

--- a/db/migrate/20170808150850_change_comment_threads_scope_to_forum.rb
+++ b/db/migrate/20170808150850_change_comment_threads_scope_to_forum.rb
@@ -3,6 +3,21 @@
 class ChangeCommentThreadsScopeToForum < ActiveRecord::Migration[5.0]
   def change
     add_reference :comment_threads, :forum, foreign_key: true
+
+    reversible do |dir|
+      dir.up do
+        Case.find_each do |c|
+          forum = Forum.create(case: c, community: nil)
+
+          CommentThread.joins(:card)
+                       .where(cards: { case_id: c.id },
+                              group_id: nil)
+                       .update_all forum_id: forum.id
+        end
+      end
+      dir.down {}
+    end
+
     remove_reference :comment_threads, :group, foreign_key: true
   end
 end

--- a/db/migrate/20170809151238_create_invitations.rb
+++ b/db/migrate/20170809151238_create_invitations.rb
@@ -1,0 +1,13 @@
+class CreateInvitations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :invitations do |t|
+      t.references :reader, foreign_key: true
+      t.references :community, foreign_key: true
+      t.integer :inviter_id
+      t.timestamp :accepted_at
+      t.timestamp :rescinded_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170809153905_add_active_community_to_reader.rb
+++ b/db/migrate/20170809153905_add_active_community_to_reader.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddActiveCommunityToReader < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :readers, :active_community,
+                  foreign_key: { to_table: :communities }
+  end
+end

--- a/db/migrate/20170809171600_add_counter_cache_for_comments_on_comment_threads.rb
+++ b/db/migrate/20170809171600_add_counter_cache_for_comments_on_comment_threads.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddCounterCacheForCommentsOnCommentThreads < ActiveRecord::Migration[5.0]
+  def change
+    add_column :comment_threads, :comments_count, :integer
+
+    CommentThread.find_each do |x|
+      CommentThread.reset_counters(x.id, :comments)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 20170809151238) do
     t.integer  "card_id"
     t.integer  "reader_id"
     t.integer  "forum_id"
+    t.integer  "comments_count"
     t.index ["card_id"], name: "index_comment_threads_on_card_id", using: :btree
     t.index ["case_id"], name: "index_comment_threads_on_case_id", using: :btree
     t.index ["forum_id"], name: "index_comment_threads_on_forum_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170721144836) do
+ActiveRecord::Schema.define(version: 20170809151238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,7 +118,6 @@ ActiveRecord::Schema.define(version: 20170721144836) do
 
   create_table "comment_threads", force: :cascade do |t|
     t.integer  "case_id"
-    t.integer  "group_id"
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.integer  "start"
@@ -128,9 +127,10 @@ ActiveRecord::Schema.define(version: 20170721144836) do
     t.string   "locale"
     t.integer  "card_id"
     t.integer  "reader_id"
+    t.integer  "forum_id"
     t.index ["card_id"], name: "index_comment_threads_on_card_id", using: :btree
     t.index ["case_id"], name: "index_comment_threads_on_case_id", using: :btree
-    t.index ["group_id"], name: "index_comment_threads_on_group_id", using: :btree
+    t.index ["forum_id"], name: "index_comment_threads_on_forum_id", using: :btree
     t.index ["reader_id"], name: "index_comment_threads_on_reader_id", using: :btree
   end
 
@@ -143,6 +143,14 @@ ActiveRecord::Schema.define(version: 20170721144836) do
     t.jsonb    "content",           default: ""
     t.index ["comment_thread_id"], name: "index_comments_on_comment_thread_id", using: :btree
     t.index ["reader_id"], name: "index_comments_on_reader_id", using: :btree
+  end
+
+  create_table "communities", force: :cascade do |t|
+    t.jsonb    "name"
+    t.integer  "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_communities_on_group_id", using: :btree
   end
 
   create_table "deployments", force: :cascade do |t|
@@ -197,6 +205,15 @@ ActiveRecord::Schema.define(version: 20170721144836) do
     t.index ["reader_id"], name: "index_enrollments_on_reader_id", using: :btree
   end
 
+  create_table "forums", force: :cascade do |t|
+    t.integer  "case_id"
+    t.integer  "community_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["case_id"], name: "index_forums_on_case_id", using: :btree
+    t.index ["community_id"], name: "index_forums_on_community_id", using: :btree
+  end
+
   create_table "group_memberships", force: :cascade do |t|
     t.integer  "reader_id"
     t.integer  "group_id"
@@ -212,6 +229,18 @@ ActiveRecord::Schema.define(version: 20170721144836) do
     t.string   "context_id"
     t.jsonb    "name",       default: ""
     t.index ["context_id"], name: "index_groups_on_context_id", using: :btree
+  end
+
+  create_table "invitations", force: :cascade do |t|
+    t.integer  "reader_id"
+    t.integer  "community_id"
+    t.integer  "inviter_id"
+    t.datetime "accepted_at"
+    t.datetime "rescinded_at"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["community_id"], name: "index_invitations_on_community_id", using: :btree
+    t.index ["reader_id"], name: "index_invitations_on_reader_id", using: :btree
   end
 
   create_table "pages", force: :cascade do |t|
@@ -356,18 +385,23 @@ ActiveRecord::Schema.define(version: 20170721144836) do
   add_foreign_key "case_elements", "cases"
   add_foreign_key "comment_threads", "cards"
   add_foreign_key "comment_threads", "cases"
-  add_foreign_key "comment_threads", "groups"
+  add_foreign_key "comment_threads", "forums"
   add_foreign_key "comment_threads", "readers"
   add_foreign_key "comments", "comment_threads"
   add_foreign_key "comments", "readers"
+  add_foreign_key "communities", "groups"
   add_foreign_key "deployments", "cases"
   add_foreign_key "deployments", "groups"
   add_foreign_key "deployments", "quizzes"
   add_foreign_key "edgenotes", "cards"
   add_foreign_key "enrollments", "cases"
   add_foreign_key "enrollments", "readers"
+  add_foreign_key "forums", "cases"
+  add_foreign_key "forums", "communities"
   add_foreign_key "group_memberships", "groups"
   add_foreign_key "group_memberships", "readers"
+  add_foreign_key "invitations", "communities"
+  add_foreign_key "invitations", "readers"
   add_foreign_key "pages", "cases"
   add_foreign_key "podcasts", "cases"
   add_foreign_key "questions", "quizzes"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170809151238) do
+ActiveRecord::Schema.define(version: 20170809171600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -314,6 +314,8 @@ ActiveRecord::Schema.define(version: 20170809151238) do
     t.string   "unconfirmed_email"
     t.boolean  "created_password",         default: true
     t.boolean  "send_reply_notifications", default: true
+    t.integer  "active_community_id"
+    t.index ["active_community_id"], name: "index_readers_on_active_community_id", using: :btree
     t.index ["confirmation_token"], name: "index_readers_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_readers_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_readers_on_reset_password_token", unique: true, using: :btree
@@ -407,4 +409,5 @@ ActiveRecord::Schema.define(version: 20170809151238) do
   add_foreign_key "podcasts", "cases"
   add_foreign_key "questions", "quizzes"
   add_foreign_key "quizzes", "cases"
+  add_foreign_key "readers", "communities", column: "active_community_id"
 end

--- a/flow-typed/actioncable.js
+++ b/flow-typed/actioncable.js
@@ -1,0 +1,30 @@
+declare class ActionCable$Consumer {
+  send(data: mixed): boolean,
+  connect(): boolean,
+  disconnect({ allowReconnect: boolean }): boolean,
+  ensureActiveConnection(): boolean,
+
+  subscriptions: ActionCable$Subscriptions,
+}
+
+declare class ActionCable$Subscription {
+  perform(action: string, data: object): boolean,
+  send(data: object): boolean,
+  unsubscribe(): void,
+
+  identifier: string,  // Stringified JSON params
+}
+
+declare class ActionCable$Subscriptions {
+  create(
+    params: string | { channel: string },
+    mixin: {[string]: Function}
+  ): ActionCable$Subscription,
+}
+
+declare type ActionCable = {
+  [key: string]: ActionCable$Subscription,
+  cable: ActionCable$Consumer,
+}
+
+declare var App: ActionCable

--- a/flow-typed/npm/@blueprintjs/core_v1.6.x.js
+++ b/flow-typed/npm/@blueprintjs/core_v1.6.x.js
@@ -71,6 +71,7 @@ declare module '@blueprintjs/core' {
     disabled?: boolean,
     text?: string,
     iconName?: string,
+    onClick?: SyntheticEvent => any,
   }
 
   declare export interface IBackdropProps {
@@ -97,6 +98,11 @@ declare module '@blueprintjs/core' {
 
   declare export interface IIntentProps {
     intent?: IntentType,
+  }
+
+  declare export interface ILinkProps {
+    href?: string,
+    target?: '_self' | '_blank' | '_parent' | '_top',
   }
 
   declare export interface IOptionProps {
@@ -195,10 +201,12 @@ declare module '@blueprintjs/core' {
   }
 
   declare export type Toast = {
+    action: IActionProps & ILinkProps,
     message: string,
     onDismiss?: (didTimoutExpire: boolean) => any,
+    iconName?: string,
     timeout?: number,
-  } & IActionProps & IProps & IIntentProps
+  } & IProps & IIntentProps
 
   declare export interface Toaster extends React$Component<*, *, *> {
     static create (

--- a/flow-typed/npm/@blueprintjs/core_v1.6.x.js
+++ b/flow-typed/npm/@blueprintjs/core_v1.6.x.js
@@ -2,35 +2,34 @@
 // flow-typed version: <<STUB>>/@blueprintjs/core_v^1.6.0/flow_v0.43.1
 
 declare module '@blueprintjs/core' {
-
   //
   // Constants
   //
-  declare export type PRIMARY = "PRIMARY"
-  declare export type SUCCESS = "SUCCESS"
-  declare export type WARNING = "WARNING"
-  declare export type DANGER = "DANGER"
+  declare export type PRIMARY = 'PRIMARY'
+  declare export type SUCCESS = 'SUCCESS'
+  declare export type WARNING = 'WARNING'
+  declare export type DANGER = 'DANGER'
   declare export type IntentType = PRIMARY | SUCCESS | WARNING | DANGER
 
   declare export interface Intent {
-    static PRIMARY: PRIMARY;
-    static SUCCESS: SUCCESS;
-    static WARNING: WARNING;
-    static DANGER: DANGER;
+    static PRIMARY: PRIMARY,
+    static SUCCESS: SUCCESS,
+    static WARNING: WARNING,
+    static DANGER: DANGER,
   }
 
-  declare export type TOP_LEFT = "TOP_LEFT"
-  declare export type TOP = "TOP"
-  declare export type TOP_RIGHT = "TOP_RIGHT"
-  declare export type RIGHT_TOP = "RIGHT_TOP"
-  declare export type RIGHT = "RIGHT"
-  declare export type RIGHT_BOTTOM = "RIGHT_BOTTOM"
-  declare export type BOTTOM_RIGHT = "BOTTOM_RIGHT"
-  declare export type BOTTOM = "BOTTOM"
-  declare export type BOTTOM_LEFT = "BOTTOM_LEFT"
-  declare export type LEFT_BOTTOM = "LEFT_BOTTOM"
-  declare export type LEFT = "LEFT"
-  declare export type LEFT_TOP = "LEFT_TOP"
+  declare export type TOP_LEFT = 'TOP_LEFT'
+  declare export type TOP = 'TOP'
+  declare export type TOP_RIGHT = 'TOP_RIGHT'
+  declare export type RIGHT_TOP = 'RIGHT_TOP'
+  declare export type RIGHT = 'RIGHT'
+  declare export type RIGHT_BOTTOM = 'RIGHT_BOTTOM'
+  declare export type BOTTOM_RIGHT = 'BOTTOM_RIGHT'
+  declare export type BOTTOM = 'BOTTOM'
+  declare export type BOTTOM_LEFT = 'BOTTOM_LEFT'
+  declare export type LEFT_BOTTOM = 'LEFT_BOTTOM'
+  declare export type LEFT = 'LEFT'
+  declare export type LEFT_TOP = 'LEFT_TOP'
   declare export type PositionType =
     | TOP_LEFT
     | TOP
@@ -46,18 +45,35 @@ declare module '@blueprintjs/core' {
     | LEFT_TOP
 
   declare export interface Position {
-    static TOP_LEFT: TOP_LEFT;
-    static TOP: TOP;
-    static TOP_RIGHT: TOP_RIGHT;
-    static RIGHT_TOP: RIGHT_TOP;
-    static RIGHT: RIGHT;
-    static RIGHT_BOTTOM: RIGHT_BOTTOM;
-    static BOTTOM_RIGHT: BOTTOM_RIGHT;
-    static BOTTOM: BOTTOM;
-    static BOTTOM_LEFT: BOTTOM_LEFT;
-    static LEFT_BOTTOM: LEFT_BOTTOM;
-    static LEFT: LEFT;
-    static LEFT_TOP: LEFT_TOP;
+    static TOP_LEFT: TOP_LEFT,
+    static TOP: TOP,
+    static TOP_RIGHT: TOP_RIGHT,
+    static RIGHT_TOP: RIGHT_TOP,
+    static RIGHT: RIGHT,
+    static RIGHT_BOTTOM: RIGHT_BOTTOM,
+    static BOTTOM_RIGHT: BOTTOM_RIGHT,
+    static BOTTOM: BOTTOM,
+    static BOTTOM_LEFT: BOTTOM_LEFT,
+    static LEFT_BOTTOM: LEFT_BOTTOM,
+    static LEFT: LEFT,
+    static LEFT_TOP: LEFT_TOP,
+  }
+
+  declare export type CLICK = 'CLICK'
+  declare export type CLICK_TARGET_ONLY = 'CLICK_TARGET_ONLY'
+  declare export type HOVER = 'HOVER'
+  declare export type HOVER_TARGET_ONLY = 'HOVER_TARGET_ONLY'
+  declare export type PopoverInteractionKindType =
+    | CLICK
+    | CLICK_TARGET_ONLY
+    | HOVER
+    | HOVER_TARGET_ONLY
+
+  declare export interface PopoverInteractionKind {
+    static CLICK: CLICK,
+    static CLICK_TARGET_ONLY: CLICK_TARGET_ONLY,
+    static HOVER: HOVER,
+    static HOVER_TARGET_ONLY: HOVER_TARGET_ONLY,
   }
 
   //
@@ -127,7 +143,7 @@ declare module '@blueprintjs/core' {
   declare export interface Button extends React$Component<*, *, *> {
     props: {
       active?: boolean,
-    } & IActionProps
+    } & IActionProps,
   }
 
   declare export interface EditableText extends React$Component<*, *, *> {
@@ -148,7 +164,8 @@ declare module '@blueprintjs/core' {
       placeholder?: string,
       selectAllOnFocus?: boolean,
       value?: string,
-    } & IProps & IIntentProps
+    } & IProps &
+      IIntentProps,
   }
 
   declare export interface Dialog extends React$Component<*, *, *> {
@@ -158,7 +175,9 @@ declare module '@blueprintjs/core' {
       isOpen: boolean,
       style: Object,
       title: string | React$Element<*>,
-    } & IProps & IBackdropProps & IOverlayableProps
+    } & IProps &
+      IBackdropProps &
+      IOverlayableProps,
   }
 
   declare export interface InputGroup extends React$Component<*, *, *> {
@@ -169,7 +188,25 @@ declare module '@blueprintjs/core' {
       placeholder?: string,
       rightElement?: React$Element<*>,
       type?: string,
-    } & IProps & IControlledProps
+    } & IProps &
+      IControlledProps,
+  }
+
+  declare export interface Menu extends React$Component<*, *, *> {
+    props: { ulRef: (ref: HTMLUListElement) => any } & IProps,
+  }
+
+  declare export interface MenuItem extends React$Component<*, *, *> {
+    props: {
+      label?: string | React$Element<*>,
+      shouldDismissPopover?: boolean,
+      submenu?: Array<$PropertyType<MenuItem, 'props'>>,
+      submenuViewportMargin?: { left?: number, right?: number },
+      text: string,
+      useSmartPositioning?: boolean,
+    } & IProps &
+      IActionProps &
+      ILinkProps,
   }
 
   declare export interface NonIdealState extends React$Component<*, *, *> {
@@ -178,15 +215,40 @@ declare module '@blueprintjs/core' {
       description?: string | React$Element<*>,
       title?: string,
       visual?: string | React$Element<*>,
-    } & IProps
+    } & IProps,
   }
 
-  declare export interface Portal extends React$Component<*, *, *> {
-
+  declare export interface Popover extends React$Component<*, *, *> {
+    props: {
+      backdropProps?: HTMLDivElement,
+      content?: string | React$Element<*>,
+      defaultIsOpen?: boolean,
+      hoverCloseDelay?: number,
+      hoverOpenDelay?: number,
+      inheritDarkTheme?: boolean,
+      interactionKind?: PopoverInteractionKindType,
+      isDisabled?: boolean,
+      isModal?: boolean,
+      isOpen?: boolean,
+      onInteraction?: (nextOpenState: boolean) => void,
+      popoverClassName?: string,
+      popoverDidOpen?: () => void,
+      popoverWillClose?: () => void,
+      popoverWillOpen?: () => void,
+      portalClassName?: string,
+      position?: PositionType,
+      rootElementTag?: string,
+      target?: string | React$Element<*>,
+      tetherOptions?: Object,
+      useSmartArrowPositioning?: boolean,
+    } & IOverlayableProps &
+      IProps,
   }
+
+  declare export interface Portal extends React$Component<*, *, *> {}
 
   declare export interface Radio extends React$Component<*, *, *> {
-    props: IControlProps & IProps
+    props: IControlProps & IProps,
   }
 
   declare export interface RadioGroup extends React$Component<*, *, *> {
@@ -197,19 +259,20 @@ declare module '@blueprintjs/core' {
       onChange: (event: SyntheticInputEvent) => any,
       options?: IOptionProps[],
       selectedValue?: string,
-    }
+    },
   }
 
   declare export type Toast = {
-    action: IActionProps & ILinkProps,
+    action?: IActionProps & ILinkProps,
     message: string,
     onDismiss?: (didTimoutExpire: boolean) => any,
     iconName?: string,
     timeout?: number,
-  } & IProps & IIntentProps
+  } & IProps &
+    IIntentProps
 
   declare export interface Toaster extends React$Component<*, *, *> {
-    static create (
+    static create(
       props: ?({
         autoFocus?: boolean,
         canEscapeKeyClear?: boolean,
@@ -218,18 +281,17 @@ declare module '@blueprintjs/core' {
       } & IProps),
       container: ?HTMLElement
     ): Toaster,
-    show (props: Toast): string,
-    update (key: string, props: Toast): void,
-    dismiss (key: string): void,
-    clear (): void,
-    getToasts (): Toast[],
+    show(props: Toast): string,
+    update(key: string, props: Toast): void,
+    dismiss(key: string): void,
+    clear(): void,
+    getToasts(): Toast[],
   }
 
   declare export interface Tooltip extends React$Component<*, *, *> {
     props: {
       isDisabled?: boolean,
       content: string,
-    } & IIntentProps
+    } & IIntentProps,
   }
-
 }

--- a/flow-typed/npm/draft-js_v0.10.x.js
+++ b/flow-typed/npm/draft-js_v0.10.x.js
@@ -11,8 +11,12 @@ declare module 'draft-js' {
     entityMap: { [string]: DraftEntity },
   }
 
-  declare export function convertFromRaw(RawDraftContentState): ContentState
-  declare export function convertToRaw(ContentState): RawDraftContentState
+  declare export function convertFromRaw(
+    rawState: RawDraftContentState
+  ): ContentState
+  declare export function convertToRaw(
+    contentState: ContentState
+  ): RawDraftContentState
 
   declare export class CharacterMetadata {
     getEntity(): string,
@@ -100,7 +104,14 @@ declare module 'draft-js' {
     static insertText(ContentState, SelectionState, string): ContentState,
   }
 
-  declare export type RawDraftContentState = Object
+  declare export type RawDraftContentState = {
+    entityMap: {
+      [string]: {
+        type: string,
+        data: Object,
+      },
+    },
+  }
 
   declare export class RichUtils {
     static handleKeyCommand(

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-truncate": "^2.0.5",
     "react-youtube-player": "^1.0.0",
     "redux": "^3.6.0",
+    "redux-batched-actions": "^0.1.6",
     "redux-logger": "^2.8.1",
     "redux-thunk": "^2.2.0",
     "sass-loader": "^6.0.3",

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :community do
+    name ''
+    group nil
+    forum
+  end
+end

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -2,7 +2,7 @@
 
 FactoryGirl.define do
   factory :community do
-    name ''
+    name { "House #{Faker::GameOfThrones.house}" }
     group nil
   end
 end

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -4,6 +4,5 @@ FactoryGirl.define do
   factory :community do
     name ''
     group nil
-    forum
   end
 end

--- a/spec/factories/deployments.rb
+++ b/spec/factories/deployments.rb
@@ -20,5 +20,10 @@ FactoryGirl.define do
       with_quiz
       answers_needed 2
     end
+
+    after :create do |this|
+      community = this.group.create_community name: this.group.name
+      community.forums.create case: this.case
+    end
   end
 end

--- a/spec/factories/forums.rb
+++ b/spec/factories/forums.rb
@@ -2,5 +2,7 @@
 
 FactoryGirl.define do
   factory :forum do
+    association :case
+    association :community
   end
 end

--- a/spec/factories/forums.rb
+++ b/spec/factories/forums.rb
@@ -3,5 +3,9 @@
 FactoryGirl.define do
   factory :forum do
     association :case
+
+    trait :with_community do
+      association :community
+    end
   end
 end

--- a/spec/factories/forums.rb
+++ b/spec/factories/forums.rb
@@ -3,6 +3,5 @@
 FactoryGirl.define do
   factory :forum do
     association :case
-    association :community
   end
 end

--- a/spec/factories/forums.rb
+++ b/spec/factories/forums.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :forum do
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -4,5 +4,9 @@ FactoryGirl.define do
   factory :group do
     name { "House #{Faker::GameOfThrones.house}" }
     context_id { Faker::Crypto.md5 }
+
+    after(:create) do |this|
+      create :community, group: this
+    end
   end
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -5,8 +5,6 @@ FactoryGirl.define do
     name { "House #{Faker::GameOfThrones.house}" }
     context_id { Faker::Crypto.md5 }
 
-    after(:create) do |this|
-      create :community, group: this
-    end
+    after(:create, &:create_community)
   end
 end

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :invitation do
+    reader nil
+    community nil
+    inviter_id nil
+  end
+end

--- a/spec/features/leaving_a_comment_spec.rb
+++ b/spec/features/leaving_a_comment_spec.rb
@@ -6,7 +6,7 @@ feature 'Leaving a comment' do
   let!(:enrollment) { create :enrollment }
   let!(:global_forum) { enrollment.case.forums.find_by community: nil }
   let!(:private_forum) do
-    private_forum = create :forum, case: enrollment.case
+    private_forum = create :forum, :with_community, case: enrollment.case
     enrollment.reader.invitations.create community: private_forum.community
   end
 

--- a/spec/features/leaving_a_comment_spec.rb
+++ b/spec/features/leaving_a_comment_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 feature 'Leaving a comment' do
   let (:enrollment) { create :enrollment }
+  let (:forum) { enrollment.case.forums.find_by community: nil }
 
   before { login_as enrollment.reader }
 
@@ -42,7 +43,8 @@ feature 'Leaving a comment' do
         block_index: 0,
         original_highlight_text: first_letter,
         reader: other_reader,
-        locale: I18n.locale
+        locale: I18n.locale,
+        forum: forum
       )
     end
 

--- a/spec/features/leaving_a_comment_spec.rb
+++ b/spec/features/leaving_a_comment_spec.rb
@@ -3,8 +3,12 @@
 require 'rails_helper'
 
 feature 'Leaving a comment' do
-  let (:enrollment) { create :enrollment }
-  let (:forum) { enrollment.case.forums.find_by community: nil }
+  let!(:enrollment) { create :enrollment }
+  let!(:global_forum) { enrollment.case.forums.find_by community: nil }
+  let!(:private_forum) do
+    private_forum = create :forum, case: enrollment.case
+    enrollment.reader.invitations.create community: private_forum.community
+  end
 
   before { login_as enrollment.reader }
 
@@ -28,26 +32,53 @@ feature 'Leaving a comment' do
     expect(find('textarea').value).to be_blank
   end
 
+  let!(:other_reader) { create :reader }
+
+  let!(:comment_thread) do
+    first_card = enrollment.case.pages.first.cards.first
+    first_letter = first_card.paragraphs[0][0]
+    first_card.comment_threads.create(
+      start: 0,
+      length: 1,
+      block_index: 0,
+      original_highlight_text: first_letter,
+      reader: other_reader,
+      locale: I18n.locale,
+      forum: global_forum
+    )
+  end
+
+  scenario 'makes it show up for other people looking at the same forum' do
+    enrollment.reader.update(active_community_id: nil)
+    visit case_path('en', enrollment.case) + '/1'
+    expect(first('.CommentThreads__banner')).to have_content 'RESPOND'
+    comment_thread.comments.create(
+      content: 'Test comment',
+      reader: other_reader
+    )
+    expect(first('.CommentThreads__banner')).to have_content '1 RESPONSE'
+
+    click_link GlobalCommunity.instance.name
+    expect(page).to have_content private_forum.community.name
+    find('.pt-menu-item', text: private_forum.community.name).click
+    expect(first('.CommentThreads__banner')).to have_content 'RESPOND'
+    comment_thread.comments.create(
+      content: 'Test comment',
+      reader: other_reader
+    )
+    expect(first('.CommentThreads__banner')).to have_content 'RESPOND'
+
+    click_link private_forum.community.name
+    find('.pt-menu-item', text: GlobalCommunity.instance.name).click
+    expect(first('.CommentThreads__banner')).to have_content '2 RESPONSES'
+    comment_thread.comments.create(
+      content: 'Test comment',
+      reader: other_reader
+    )
+    expect(first('.CommentThreads__banner')).to have_content '3 RESPONSES'
+  end
+
   context 'in response to another comment' do
-    let!(:other_reader) do
-      other_reader = create :reader
-    end
-
-    let!(:comment_thread) do
-      first_card = enrollment.case.pages.first.cards.first
-      first_letter = first_card.paragraphs[0][0]
-      comment_thread = first_card.comment_threads.create(
-        id: 4444,
-        start: 0,
-        length: 1,
-        block_index: 0,
-        original_highlight_text: first_letter,
-        reader: other_reader,
-        locale: I18n.locale,
-        forum: forum
-      )
-    end
-
     let!(:comment) do
       comment_thread.comments.create(
         content: 'Test comment',
@@ -84,7 +115,9 @@ feature 'Leaving a comment' do
       expect(page).to have_content 'replied to your comment'
     end
 
-    it 'sends an email to the other comment’s author' do
+    it 'sends an email to the other comment’s author with a link that works ' \
+       'even when it the reader is in a different active community' do
+      enrollment.reader.update(active_community_id: private_forum.community.id)
       comment_thread.comments.create content: 'Test reply',
                                      reader: enrollment.reader
       email = ActionMailer::Base.deliveries.last
@@ -92,6 +125,10 @@ feature 'Leaving a comment' do
       expect(email.to.first).to eq other_reader.email
       expect(email.text_part.body.to_s).to match 'Test reply'
       expect(email.html_part.body.to_s).to match 'Test reply'
+
+      link = email.text_part.body.match(%r{Reply online.+//[^/]+(/.+)\)})[1]
+      visit link
+      expect(page).to have_content 'Test reply'
     end
 
     it 'doesn’t send an email notification if the other author has ' \

--- a/spec/features/viewing_a_case_spec.rb
+++ b/spec/features/viewing_a_case_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 feature 'Viewing a case' do
   context 'while not logged in' do
-    let!(:kase) { create :case_with_elements, :published}
+    let!(:kase) { create :case_with_elements, :published }
 
     scenario 'is possible' do
       visit root_path
@@ -35,6 +35,25 @@ feature 'Viewing a case' do
         click_link published_case.title
         click_link published_case.pages.first.title
         expect(page).not_to have_selector '.c-statistics'
+      end
+
+      context 'without a forum for your active community' do
+        scenario 'the community chooser displays the community as inactive' do
+          invited_community = create :community
+          user.invitations.create community: invited_community
+          user.update active_community_id: invited_community.id
+
+          visit case_path('en', published_case)
+          click_button 'Enroll'
+          expect(page).to have_content "#{invited_community.name} ▾"
+          find_link(invited_community.name).hover
+          expect(find_link(invited_community.name)).to have_selector '.pt-icon-cross'
+
+          click_link(published_case.pages.first.title)
+          click_link(invited_community.name)
+          find('.pt-menu-item', text: GlobalCommunity.instance.name).click
+          expect(first('.CommentThreads__banner')).to have_content 'RESPOND'
+        end
       end
     end
 

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Community, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/forum_spec.rb
+++ b/spec/models/forum_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Forum, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Invitation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/reader_spec.rb
+++ b/spec/models/reader_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Reader, type: :model do
     subject.groups << group
 
     expect(subject.communities).to include(invited_community,
-                                           group.community,
-                                           GlobalCommunity.instance)
+                                           group.community)
   end
 end

--- a/spec/models/reader_spec.rb
+++ b/spec/models/reader_spec.rb
@@ -13,4 +13,18 @@ RSpec.describe Reader, type: :model do
     subject.save
     expect(subject.created_password).to be true
   end
+
+  it 'has access to the right communities' do
+    subject.save
+
+    invited_community = create :community
+    create :invitation, reader: subject, community: invited_community
+
+    group = create :group
+    subject.groups << group
+
+    expect(subject.communities).to include(invited_community,
+                                           group.community,
+                                           GlobalCommunity.instance)
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4768,6 +4768,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-batched-actions@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/redux-batched-actions/-/redux-batched-actions-0.1.6.tgz#47be903d16378bae13611ced754ab419b66b632a"
+
 redux-logger@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-2.8.1.tgz#c00e689ba00342f44858701d76b1d73fbade72bd"


### PR DESCRIPTION
This PR creates multiple forums on every case and allows the user to switch between them to see different comment threads. All users are members of the global community, and then users are members of any communities they have Invitations to, and the communities associated with any groups that they are members of. Whatever comments have been made within that community’s forum on that case are the only ones visible while that community is active. A user’s active community as saved as an attribute on their profile, and shown in a community chooser below the case’s billboard, even if that community is not actively discussing that case. Direct links to a comment thread do automatically change a user’s active community for them. 

**Migrations: YES**

![screen shot 2017-08-28 at 18 00 15](https://user-images.githubusercontent.com/4642599/29795569-cb4f8174-8c1a-11e7-9554-fe180d470c0a.jpg)

Known issues: #84