### PR TITLE
Allows editors to change authors and translators

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -82,8 +82,8 @@ class CasesController < ApplicationController
   # Only allow a trusted parameter "white list" through.
   def case_params
     params.require(:case).permit(
-      :published, :kicker, :title, :dek, :slug, :translators, :photo_credit,
-      :summary, :tags, :cover_url, authors: [], learning_objectives: []
+      :published, :kicker, :title, :dek, :slug, :photo_credit,
+      :summary, :tags, :cover_url, authors: [], translators: [], learning_objectives: []
     )
   end
 end

--- a/app/javascript/overview/AuthorsList.jsx
+++ b/app/javascript/overview/AuthorsList.jsx
@@ -54,11 +54,12 @@ class AuthorsList extends React.Component {
               {translatorsString}
             </em>}
         </p>
-        <AuthorsListForm
-          byline={byline}
-          editing={this.state.editing}
-          onFinishEditing={this.handleFinishEditing}
-        />
+        {canEdit &&
+          <AuthorsListForm
+            byline={byline}
+            editing={this.state.editing}
+            onFinishEditing={this.handleFinishEditing}
+          />}
       </div>
     )
   }

--- a/app/javascript/overview/AuthorsList.jsx
+++ b/app/javascript/overview/AuthorsList.jsx
@@ -1,0 +1,67 @@
+/**
+ * @providesModule AuthorsList
+ * @flow
+ */
+
+import React from 'react'
+
+import { acceptKeyboardClick } from 'shared/keyboard'
+import AuthorsListForm from './AuthorsListForm'
+
+import type { Byline } from 'redux/state'
+import type { AuthorsListFormState } from './AuthorsListForm'
+
+class AuthorsList extends React.Component {
+  props: {
+    canEdit: boolean,
+    byline: Byline,
+    onChange: Byline => any,
+  }
+  state = { editing: false }
+
+  handleStartEditing = (e: SyntheticEvent) => {
+    if (this.props.canEdit) this.setState({ editing: true })
+  }
+
+  handleFinishEditing = (formState: ?AuthorsListFormState) => {
+    this.setState({ editing: false })
+    if (formState != null) {
+      this.props.onChange({
+        ...formState,
+        authorsString: formState.authors.join(' • '),
+        translatorsString: `Translators: ${formState.translators.join(' • ')}`,
+      })
+    }
+  }
+
+  render () {
+    const { canEdit, byline } = this.props
+    const { authorsString, translatorsString } = byline
+
+    return (
+      <div
+        tabIndex="0"
+        role="button"
+        style={{ cursor: canEdit ? 'pointer' : 'auto' }}
+        onKeyPress={acceptKeyboardClick(this.handleStartEditing)}
+        onClick={this.handleStartEditing}
+      >
+        <p>
+          {authorsString}
+          <br />
+          {translatorsString !== '' &&
+            <em>
+              {translatorsString}
+            </em>}
+        </p>
+        <AuthorsListForm
+          byline={byline}
+          editing={this.state.editing}
+          onFinishEditing={this.handleFinishEditing}
+        />
+      </div>
+    )
+  }
+}
+
+export default AuthorsList

--- a/app/javascript/overview/AuthorsListForm.jsx
+++ b/app/javascript/overview/AuthorsListForm.jsx
@@ -1,0 +1,124 @@
+/**
+ * @providesModule AuthorsList
+ * @flow
+ */
+
+import React from 'react'
+import { connect } from 'react-redux'
+import styled from 'styled-components'
+
+import { Button, Dialog, Intent } from '@blueprintjs/core'
+
+import { displayToast } from 'redux/actions'
+import { isCompact } from 'shared/functions'
+
+import SortableList, { createSortableInput } from 'utility/SortableList'
+
+import type { Toast } from '@blueprintjs/core'
+import type { Byline } from 'redux/state'
+
+type Props = {
+  editing: boolean,
+  byline: Byline,
+  displayToast: Toast => void,
+  onFinishEditing: (?AuthorsListFormState) => void,
+}
+export type AuthorsListFormState = { authors: string[], translators: string[] }
+
+class AuthorsListForm extends React.Component {
+  props: Props
+  state: AuthorsListFormState
+
+  constructor (props: Props) {
+    super(props)
+
+    const { authors, translators } = props.byline
+    this.state = { authors, translators }
+  }
+
+  handleChangeAuthors = (authors: string[]) => {
+    this.setState({ authors })
+  }
+
+  handleChangeTranslators = (translators: string[]) => {
+    this.setState({ translators })
+  }
+
+  handleCancel = () => {
+    this.props.onFinishEditing(null)
+  }
+
+  handleDone = () => {
+    if (formStateClean(this.state)) {
+      this.props.onFinishEditing(this.state)
+    } else {
+      this.props.displayToast({
+        message: 'You missed something!',
+        intent: Intent.WARNING,
+      })
+    }
+  }
+
+  render () {
+    const { editing } = this.props
+    const { authors, translators } = this.state
+    return (
+      <Dialog
+        isOpen={editing}
+        iconName="edit"
+        className="pt-dark"
+        title="Editing authors and translators"
+        style={{ width: 700 }}
+        onClose={this.handleCancel}
+      >
+        <div className="pt-dialog-body">
+          <SectionTitle>Authors</SectionTitle>
+          <SortableList
+            dark
+            items={authors}
+            newItem=""
+            render={AuthorInput}
+            onChange={this.handleChangeAuthors}
+          />
+
+          <SectionTitle>Translators</SectionTitle>
+          <SortableList
+            dark
+            items={translators}
+            newItem=""
+            render={TranslatorInput}
+            onChange={this.handleChangeTranslators}
+          />
+        </div>
+        <div className="pt-dialog-footer">
+          <div className="pt-dialog-footer-actions">
+            <Button text="Cancel" onClick={this.handleCancel} />
+            <Button
+              intent={Intent.SUCCESS}
+              text="Done"
+              onClick={this.handleDone}
+            />
+          </div>
+        </div>
+      </Dialog>
+    )
+  }
+}
+
+export default connect(undefined, { displayToast })(AuthorsListForm)
+
+function formStateClean ({
+  authors,
+  translators,
+}: AuthorsListFormState): boolean {
+  return isCompact(authors) && isCompact(translators)
+}
+
+const AuthorInput = createSortableInput({ placeholder: 'Author name' })
+const TranslatorInput = createSortableInput({ placeholder: 'Translator name' })
+
+const SectionTitle = styled.h5`
+  &:not(:first-child) {
+    margin-top: 2em;
+  }
+`

--- a/app/javascript/overview/BillboardTitle.jsx
+++ b/app/javascript/overview/BillboardTitle.jsx
@@ -10,7 +10,9 @@ import { EditableText } from '@blueprintjs/core'
 
 import { updateCase } from 'redux/actions'
 
-import type { State, CaseDataState } from 'redux/state'
+import AuthorsList from './AuthorsList'
+
+import type { State, CaseDataState, Byline } from 'redux/state'
 
 function mapStateToProps ({ edit, caseData }: State) {
   const {
@@ -18,8 +20,10 @@ function mapStateToProps ({ edit, caseData }: State) {
     kicker,
     title,
     photoCredit,
-    caseAuthors,
+    authors,
+    authorsString,
     translators,
+    translatorsString,
     coverUrl,
   } = caseData
 
@@ -28,9 +32,8 @@ function mapStateToProps ({ edit, caseData }: State) {
     kicker,
     title,
     photoCredit,
-    caseAuthors,
-    translators,
     coverUrl,
+    byline: { authors, translators, authorsString, translatorsString },
     editing: edit.inProgress,
   }
 }
@@ -41,8 +44,7 @@ type Props = {
   kicker: string,
   title: string,
   photoCredit: string,
-  caseAuthors: string,
-  translators: string,
+  byline: Byline,
   coverUrl: string,
   updateCase: (string, $Shape<CaseDataState>) => void,
   minimal: boolean,
@@ -53,8 +55,7 @@ export const UnconnectedBillboardTitle = ({
   kicker,
   title,
   photoCredit,
-  caseAuthors,
-  translators,
+  byline,
   coverUrl,
   updateCase,
   minimal,
@@ -87,15 +88,11 @@ export const UnconnectedBillboardTitle = ({
       </h1>
 
       {!minimal &&
-        caseAuthors !== '' &&
-        <p>
-          {caseAuthors}
-          <br />
-          {translators !== '' &&
-            <em>
-              {translators}
-            </em>}
-        </p>}
+        <AuthorsList
+          canEdit={editing}
+          byline={byline}
+          onChange={(value: Byline) => updateCase(slug, value)}
+        />}
 
       <cite className="o-bottom-right c-photo-credit">
         {minimal ||

--- a/app/javascript/overview/BillboardTitle.jsx
+++ b/app/javascript/overview/BillboardTitle.jsx
@@ -33,7 +33,10 @@ function mapStateToProps ({ edit, caseData }: State) {
     title,
     photoCredit,
     coverUrl,
-    byline: { authors, translators, authorsString, translatorsString },
+    authors,
+    translators,
+    authorsString,
+    translatorsString,
     editing: edit.inProgress,
   }
 }
@@ -44,18 +47,21 @@ type Props = {
   kicker: string,
   title: string,
   photoCredit: string,
-  byline: Byline,
   coverUrl: string,
   updateCase: (string, $Shape<CaseDataState>) => void,
   minimal: boolean,
-}
+} & Byline
+
 export const UnconnectedBillboardTitle = ({
   editing,
   slug,
   kicker,
   title,
   photoCredit,
-  byline,
+  authors,
+  translators,
+  authorsString,
+  translatorsString,
   coverUrl,
   updateCase,
   minimal,
@@ -90,7 +96,12 @@ export const UnconnectedBillboardTitle = ({
       {!minimal &&
         <AuthorsList
           canEdit={editing}
-          byline={byline}
+          byline={{
+            authors,
+            translators,
+            authorsString,
+            translatorsString,
+          }}
           onChange={(value: Byline) => updateCase(slug, value)}
         />}
 

--- a/app/javascript/podcast/CreditsListForm.jsx
+++ b/app/javascript/podcast/CreditsListForm.jsx
@@ -6,11 +6,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
-import { compose, isEmpty, map, none, values, flatten } from 'ramda'
 
 import { Button, Dialog, Intent } from '@blueprintjs/core'
 
 import { displayToast } from 'redux/actions'
+import { isCompact, areObjectsCompact } from 'shared/functions'
 
 import SortableList, { createSortableInput } from 'utility/SortableList'
 
@@ -106,12 +106,6 @@ class CreditsListForm extends React.Component {
 }
 
 export default connect(undefined, { displayToast })(CreditsListForm)
-
-const listValues = map(values)
-const isCompact = none(isEmpty)
-
-// $FlowFixMe
-const areObjectsCompact = compose(isCompact, flatten, listValues)
 
 function formStateClean ({ guests, hosts }: CreditsListFormState): boolean {
   return areObjectsCompact(guests) && isCompact(hosts)

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -112,6 +112,8 @@ async function saveModel (endpoint: string, state: State): Promise<Object> {
           summary,
           baseCoverUrl,
           learningObjectives,
+          authors,
+          translators,
         } = state.caseData
         data = {
           case: {
@@ -123,6 +125,8 @@ async function saveModel (endpoint: string, state: State): Promise<Object> {
             photoCredit,
             summary,
             learningObjectives,
+            authors,
+            translators,
             coverUrl: baseCoverUrl,
           },
         }

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -31,7 +31,6 @@ export type CardsState = {
 export type CaseDataState = {
   audience: string,
   baseCoverUrl: string,
-  caseAuthors: string,
   caseElements: CaseElement[],
   commentable: boolean,
   coverUrl: string,
@@ -47,8 +46,7 @@ export type CaseDataState = {
   smallCoverUrl: string,
   summary: string,
   title: string,
-  translators: string,
-}
+} & Byline
 
 export type CommentThreadsState = {
   [commentThreadId: string]: CommentThread,
@@ -125,6 +123,13 @@ export type Activity = {
   position: number,
   title: string,
   url: string,
+}
+
+export type Byline = {
+  authors: string[],
+  authorsString: string,
+  translators: string[],
+  translatorsString: string,
 }
 
 export type Card = {

--- a/app/javascript/shared/functions.js
+++ b/app/javascript/shared/functions.js
@@ -1,0 +1,19 @@
+/**
+ * @flow
+ */
+
+import { compose, isEmpty, map, none, values, flatten } from 'ramda'
+
+const listValues = map(values)
+
+// Returns true if input array has no blank elements
+// isCompact(["a", "", "c"]) => false
+export const isCompact: (string[]) => boolean = none(isEmpty)
+
+// Returns true if input array has no elements with any blank values
+// isCompact([{a: "1", b: "2"}, {a: "", b: "2"}]) => false
+export const areObjectsCompact: (Object[]) => boolean = compose(
+  isCompact,
+  flatten,
+  listValues
+)

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -42,10 +42,6 @@ class Case < ApplicationRecord
     slug
   end
 
-  def case_authors
-    authors.to_sentence
-  end
-
   def events
     Ahoy::Event.for_case self
   end

--- a/app/views/cases/_case.html.haml
+++ b/app/views/cases/_case.html.haml
@@ -18,4 +18,4 @@
       - unless c.dek.blank?
         = c.dek
       - else
-        = c.case_authors
+        = c.authors.to_sentence

--- a/app/views/cases/_case.json.jbuilder
+++ b/app/views/cases/_case.json.jbuilder
@@ -2,14 +2,17 @@
 
 json.key_format! camelize: :lower
 
-json.extract! c, :slug, :published, :kicker, :title, :dek, :case_authors,
-              :summary, :tags, :photo_credit, :other_available_locales,
-              :commentable, :learning_objectives, :audience
+json.extract! c, :slug, :published, :kicker, :title, :dek, :authors,
+              :translators, :summary, :tags, :photo_credit,
+              :other_available_locales, :commentable, :learning_objectives,
+              :audience
+
+json.authors_string c.authors.to_sentence
+json.translators_string translators_string c
 
 json.base_cover_url c.cover_url
 json.small_cover_url ix_cover_image(c, :small)
 json.cover_url ix_cover_image(c, :billboard)
-json.translators translators_string c
 
 json.page_ids c.pages.map(&:id)
 json.case_elements c.case_elements do |case_element|

--- a/app/views/cases/index.json.jbuilder
+++ b/app/views/cases/index.json.jbuilder
@@ -1,10 +1,11 @@
 json.array! @cases do |c|
   json.key_format! camelize: :lower
-  json.extract! c, *%i(slug published kicker title dek case_authors summary tags photo_credit)
+  json.extract! c, *%i(slug published kicker title dek authors translators summary tags photo_credit)
+  json.authors_string c.authors.to_sentence
+  json.translators_string translators_string c
   json.base_cover_url c.cover_url
   json.small_cover_url ix_cover_image(c, :small)
   json.cover_url ix_cover_image(c, :billboard)
-  json.translators translators_string c
   if reader_signed_in?
     if current_reader.can_update? c
       json.enrollments do


### PR DESCRIPTION
Based on podcast CreditsList implementation, we're using
SortableList in a pop up dialog to make it happen.

To make it more clear for sending the data down, `caseAuthors` has been
replaced by `authorsString`, `translators` by `translatorsString` and
`translators` is now an array of strings.