### PR TITLE
Makes “edit profile” route a singular resource :profile

### DIFF
--- a/app/controllers/readers_controller.rb
+++ b/app/controllers/readers_controller.rb
@@ -2,10 +2,10 @@
 
 class ReadersController < ApplicationController
   before_action :authenticate_reader!
-  before_action :set_reader, only: %i[show edit update destroy]
+  before_action :set_reader, only: %i[edit update destroy]
   layout 'window'
 
-  authorize_actions_for Case, except: %i[show edit update]
+  authorize_actions_for Case, except: %i[edit update]
 
   # GET /readers
   # GET /readers.json
@@ -16,34 +16,9 @@ class ReadersController < ApplicationController
     render layout: 'admin'
   end
 
-  # GET /readers/1
-  # GET /readers/1.json
-  def show; end
-
-  # GET /readers/new
-  def new
-    @reader = Reader.new
-  end
-
   # GET /readers/1/edit
   def edit
     authorize_action_for @reader
-  end
-
-  # POST /readers
-  # POST /readers.json
-  def create
-    @reader = Reader.new(reader_params)
-
-    respond_to do |format|
-      if @reader.save
-        format.html { redirect_to @reader, notice: 'Reader was successfully created.' }
-        format.json { render :show, status: :created, location: @reader }
-      else
-        format.html { render :new }
-        format.json { render json: @reader.errors, status: :unprocessable_entity }
-      end
-    end
   end
 
   # PATCH/PUT /readers/1
@@ -53,7 +28,7 @@ class ReadersController < ApplicationController
     respond_to do |format|
       if @reader.update(reader_params)
         bypass_sign_in @reader if reader_params.key? :password
-        format.html { redirect_to profile_path, notice: 'Reader was successfully updated.' }
+        format.html { redirect_to edit_profile_path, notice: 'Reader was successfully updated.' }
         format.json { render :show, status: :ok, location: @reader }
       else
         format.html { render :edit }

--- a/app/controllers/readers_controller.rb
+++ b/app/controllers/readers_controller.rb
@@ -53,7 +53,7 @@ class ReadersController < ApplicationController
     respond_to do |format|
       if @reader.update(reader_params)
         bypass_sign_in @reader if reader_params.key? :password
-        format.html { redirect_to edit_reader_path(@reader), notice: 'Reader was successfully updated.' }
+        format.html { redirect_to profile_path, notice: 'Reader was successfully updated.' }
         format.json { render :show, status: :ok, location: @reader }
       else
         format.html { render :edit }
@@ -76,7 +76,11 @@ class ReadersController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_reader
-    @reader = Reader.find(params[:id])
+    @reader = if params[:id].blank?
+                current_reader
+              else
+                Reader.find(params[:id])
+              end
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/views/layouts/with_header.html.erb
+++ b/app/views/layouts/with_header.html.erb
@@ -6,7 +6,7 @@
     <div id="reader-menu">
       <div id="reader-menu-dismiss" class="hidden dismiss menu-dismiss"></div>
       <ul id="reader-menu-dropdown" class="hidden">
-        <li><%=link_to t('readers.form.my_account'), edit_reader_path(current_reader) %></li>
+        <li><%=link_to t('readers.form.my_account'), edit_profile_path %></li>
         <li><%=link_to t('devise.sessions.destroy'), destroy_reader_session_path, method: :delete %></li>
       </ul>
       <div id="reader-icon"<%= raw " style=\"background-image: url('#{current_reader.image_url}')\"" unless current_reader.image_url.blank? %>>

--- a/app/views/readers/_form.html.haml
+++ b/app/views/readers/_form.html.haml
@@ -1,6 +1,6 @@
 .dialog.devise
   %h2= t '.my_account'
-  = form_for @reader do |f|
+  = form_for @reader, url: :profile do |f|
     .pt-control-group.pt-fill
       = f.label :name, class: "pt-label" do
         = t 'activerecord.attributes.reader.name'
@@ -33,7 +33,7 @@
     %p=link_to t('devise.registrations.edit.change_my_password'), edit_reader_registration_path
   - else
     %h2= t '.create_a_password'
-    = form_for @reader do |f|
+    = form_for @reader, url: :profile do |f|
       %p.pt-text-muted= t '.you_have_not_created_a_password', provider: @reader.providers.first.capitalize
       = f.label :password, class: 'pt-label' do
         = t 'activerecord.attributes.user.password'

--- a/app/views/reply_notification_mailer/notify.markerb
+++ b/app/views/reply_notification_mailer/notify.markerb
@@ -10,7 +10,7 @@
 You are receiving this email because someone replied to a comment you made on a
 Michigan Sustainability Case you’re studying. If you do not want to receive
 emails like this, you can [change your notification settings](#{
-  edit_reader_url @notification.reader.locale, @notification.reader
+  edit_profile_url @notification.reader.locale
 }).
 FOOTER
 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
       confirmations: 'readers/confirmations'
     }
 
-    resources :readers, only: %i[show edit update]
+    resource :profile, controller: :readers, only: %i[edit update]
 
     resources :quizzes, only: %i[create update] do
       resources :submissions, only: %i[create]


### PR DESCRIPTION
This is simpler because we don’t need to pass around the reader id and
safer because we’re not exposing it in the URL.