### PR TITLE
Prevent the baking-in of comments

### DIFF
--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -500,7 +500,16 @@ export function updateActiveCommunity (
   slug: string,
   id: string | null
 ): ThunkAction {
-  return async (dispatch: Dispatch) => {
+  return async (dispatch: Dispatch, getState: () => State) => {
+    if (getState().edit.changed) {
+      if (
+        !window.confirm(
+          'Changing the active community while you have unsaved changes will reset all cards resulting in the loss of your changes. Continue?'
+        )
+      ) {
+        return
+      }
+    }
     await Orchard.espalier(`profile`, { reader: { activeCommunityId: id }})
     dispatch(fetchCommunities(slug))
     dispatch(fetchCommentThreads(slug))

--- a/app/javascript/redux/reducers/caseData.js
+++ b/app/javascript/redux/reducers/caseData.js
@@ -15,6 +15,7 @@ import type {
   AddPodcastAction,
   AddActivityAction,
   SetCommunitiesAction,
+  ToggleEditingAction,
 } from 'redux/actions'
 
 import type { CaseDataState } from 'redux/state'
@@ -29,6 +30,7 @@ type Action =
   | AddPodcastAction
   | AddActivityAction
   | SetCommunitiesAction
+  | ToggleEditingAction
 
 export default function caseData (
   state: CaseDataState = ({ ...window.caseData }: CaseDataState),
@@ -94,6 +96,9 @@ export default function caseData (
             (state.reader && state.reader.activeCommunity),
         },
       }
+
+    case 'TOGGLE_EDITING':
+      return { ...state, commentable: false }
 
     default:
       return state


### PR DESCRIPTION
Since comment threads are applied to cards as draft-js entities just like edgenotes, if a card is edited and saved while a comment thread is visible that underlined entity will be saved in the database and will be visible even when the associated comment thread object is not loaded. To fix it, we'll simply remove all the comments from the cards when the user enters edit mode. It is reasonable, at least for now, to ask our editors to refresh the page to get the comments back...

Fixes half of #84 