### PR TITLE
Uses strong params for raw content

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,9 @@ AllCops:
   TargetRubyVersion: 2.3
 Style/AsciiComments:
   Enabled: false
+Style/Lambda:
+  EnforcedStyle: literal
+Style/LambdaCall:
+  Enabled: false
 Security/YAMLLoad:
   Enabled: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sieve'
+
 class ApplicationController < ActionController::Base
   before_action :store_current_location, unless: :devise_controller?
   before_action :set_locale

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -43,7 +43,7 @@ class CardsController < ApplicationController
   end
 
   def card_params
-    Sv.hash_of.(
+    Sv.hash_of(
       position: Sv.scalar,
       solid: Sv.scalar,
       raw_content: raw_draft_content_state
@@ -51,24 +51,24 @@ class CardsController < ApplicationController
   end
 
   def raw_draft_content_state
-    camelize.(
-      Sv.struct_of.(
-        blocks: Sv.array_of.(
-          Sv.hash_of.(
+    camelize(
+      Sv.struct_of(
+        blocks: Sv.array_of(
+          Sv.hash_of(
             key: Sv.scalar,
             type: Sv.scalar,
             text: Sv.scalar,
             depth: Sv.scalar,
             data: Sv.anything,
-            inlineStyleRanges: Sv.array_of.(
-              Sv.struct_of.(
-                style: Sv.one_of.(%w[BOLD ITALIC]),
+            inlineStyleRanges: Sv.array_of(
+              Sv.struct_of(
+                style: Sv.one_of(%w[BOLD ITALIC]),
                 offset: Sv.scalar,
                 length: Sv.scalar
               )
             ),
-            entityRanges: Sv.array_of.(
-              Sv.struct_of.(
+            entityRanges: Sv.array_of(
+              Sv.struct_of(
                 key: Sv.scalar,
                 offset: Sv.scalar,
                 length: Sv.scalar
@@ -76,8 +76,8 @@ class CardsController < ApplicationController
             )
           )
         ),
-        entityMap: Sv.map_of.(
-          Sv.struct_of.(
+        entityMap: Sv.map_of(
+          Sv.struct_of(
             type: Sv.scalar,
             mutability: Sv.scalar,
             data: Sv.anything
@@ -89,13 +89,13 @@ class CardsController < ApplicationController
 
   # We have to send this over the wire stringified to prevent the keys from
   # being made snake_case
-  def camelize
-    ->(fn, hash) {
+  def camelize(fn)
+    ->(hash) {
       unless hash.is_a?(Hash) || hash.is_a?(ActionController::Parameters)
         return nil
       end
 
       fn.call(hash.permit!.to_h.deep_transform_keys! { |x| x.camelize(:lower) })
-    }.curry
+    }
   end
 end

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -150,9 +150,7 @@ async function saveModel (endpoint: string, state: State): Promise<Object> {
           state.cardsById[id].editorState || EditorState.createEmpty()
         data = {
           card: {
-            rawContent: JSON.stringify(
-              convertToRaw(editorState.getCurrentContent())
-            ),
+            rawContent: convertToRaw(editorState.getCurrentContent()),
           },
         }
       }

--- a/app/javascript/redux/reducers/cards.js
+++ b/app/javascript/redux/reducers/cards.js
@@ -149,9 +149,8 @@ function sortCommentThreads (a: CommentThread, b: CommentThread): number {
 }
 
 function parseEditorStateFromPersistedCard (card: Card) {
-  const content = card.rawContent
-    ? (JSON.parse(card.rawContent): RawDraftContentState)
-    : convertFromOldStyleCardSerialization(card.content)
+  const content =
+    card.rawContent || convertFromOldStyleCardSerialization(card.content)
   if (content == null) return EditorState.createEmpty()
 
   const contentWithCommentThreads = addCommentThreads(content, card)

--- a/app/javascript/redux/state.js
+++ b/app/javascript/redux/state.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import type { EditorState } from 'draft-js'
+import type { EditorState, RawDraftContentState } from 'draft-js'
 
 // Redux state
 export type { State } from 'redux/reducers'
@@ -125,7 +125,7 @@ export type Card = {
   editorState: ?EditorState,
   id: string,
   position: number,
-  rawContent: string,
+  rawContent: ?RawDraftContentState,
   solid: boolean,
 }
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -15,7 +15,9 @@ class Card < ApplicationRecord
   before_save :set_case_from_element
 
   def paragraphs
-    JSON.parse(raw_content)['blocks'].map { |x| x['text'] }
+    raw_content['blocks'].map { |x| x['text'] }
+  rescue
+    []
   end
 
   include Trackable

--- a/db/migrate/20170830013418_convert_raw_content_to_json.rb
+++ b/db/migrate/20170830013418_convert_raw_content_to_json.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ConvertRawContentToJson < ActiveRecord::Migration[5.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        Card.find_each do |card|
+          raw_content = card.read_attribute(:raw_content)
+                            .each_with_object({}) do |(key, value), hash|
+            hash[key] = JSON.parse value
+          end
+          card.write_attribute :raw_content, raw_content
+          card.save
+        end
+      end
+
+      dir.down do
+        Card.find_each do |card|
+          raw_content = card.read_attribute(:raw_content)
+                            .each_with_object({}) do |(key, value), hash|
+            hash[key] = JSON.dump value
+          end
+          card.write_attribute :raw_content, raw_content
+          card.save
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170809171600) do
+ActiveRecord::Schema.define(version: 20170830013418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/flow-typed/npm/draft-js_v0.10.x.js
+++ b/flow-typed/npm/draft-js_v0.10.x.js
@@ -105,6 +105,19 @@ declare module 'draft-js' {
   }
 
   declare export type RawDraftContentState = {
+    blocks: $Array<{
+      key: string,
+      type: string,
+      text: string,
+      depth: number,
+      data: Object,
+      inlineStyleRanges: $Array<{
+        style: string,
+        offset: number,
+        length: number,
+      }>,
+      entityRanges: $Array<{ key: string, offset: number, length: number }>,
+    }>,
     entityMap: {
       [string]: {
         type: string,

--- a/lib/sieve.rb
+++ b/lib/sieve.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# A functional, composable way of filtering parameters.
+# http://blog.martinosis.com/blog/simple-functional-strong-params-in-ruby/
+
+class Sv
+  mattr_accessor :hash_of, :struct_of, :map_of, :array_of, :one_of, :scalar,
+                 :anything, :default
+
+  # Filters out any unknown keys or known keys of the wrong type
+  @@hash_of = ->(fields, hash) {
+    hash ||= {}
+    fields.map { |key, fn| [key, fn.call(hash[key])] }.to_h.compact
+  }.curry
+
+  # All or nothing hash_of; nullifies the object if it doesn’t have all the
+  # right keys with all the right types of values
+  @@struct_of = ->(fields, hash) {
+    clean_hash = @@hash_of.(fields, hash)
+    (fields.keys - clean_hash.keys).empty? ? clean_hash : nil
+  }.curry
+
+  # Accepts any key except those with values of the wrong type
+  @@map_of = ->(fn, hash) {
+    hash ||= {}
+    hash = hash.permit!.to_h if hash.is_a? ActionController::Parameters
+
+    hash.map do |key, value|
+      filtered_value = fn.call(value)
+      filtered_value.blank? ? nil : [key, fn.call(value)]
+    end.compact.to_h
+  }.curry
+
+  # Filters out elements of the wrong type
+  @@array_of = ->(fn, value) {
+    value.is_a?(Array) ? value.map(&fn).compact : []
+  }.curry
+
+  # Provides a default
+  @@default = ->(default, a) { a.blank? ? default : a }.curry
+
+  # Filters out any values not present in the provided array
+  @@one_of = ->(options, a) { options.include?(a) ? a : nil }.curry
+
+  # Accepts any scalar value
+  @@scalar = ->(a) { a.is_a?(Array) || a.is_a?(Hash) ? nil : a }
+
+  # Accepts any data structure
+  @@anything = :itself.to_proc
+end

--- a/lib/sieve.rb
+++ b/lib/sieve.rb
@@ -8,43 +8,59 @@ class Sv
                  :anything, :default
 
   # Filters out any unknown keys or known keys of the wrong type
-  @@hash_of = ->(fields, hash) {
-    hash ||= {}
-    fields.map { |key, fn| [key, fn.call(hash[key])] }.to_h.compact
-  }.curry
+  def self.hash_of(fields)
+    ->(hash) {
+      hash ||= {}
+      fields.map { |key, fn| [key, fn.call(hash[key])] }.to_h.compact
+    }
+  end
 
   # All or nothing hash_of; nullifies the object if it doesn’t have all the
   # right keys with all the right types of values
-  @@struct_of = ->(fields, hash) {
-    clean_hash = @@hash_of.(fields, hash)
-    (fields.keys - clean_hash.keys).empty? ? clean_hash : nil
-  }.curry
+  def self.struct_of(fields)
+    ->(hash) {
+      clean_hash = Sv.hash_of(fields).(hash)
+      (fields.keys - clean_hash.keys).empty? ? clean_hash : nil
+    }
+  end
 
   # Accepts any key except those with values of the wrong type
-  @@map_of = ->(fn, hash) {
-    hash ||= {}
-    hash = hash.permit!.to_h if hash.is_a? ActionController::Parameters
+  def self.map_of(fn)
+    ->(hash) {
+      hash ||= {}
+      hash = hash.permit!.to_h if hash.is_a? ActionController::Parameters
 
-    hash.map do |key, value|
-      filtered_value = fn.call(value)
-      filtered_value.blank? ? nil : [key, fn.call(value)]
-    end.compact.to_h
-  }.curry
+      hash.map do |key, value|
+        filtered_value = fn.call(value)
+        filtered_value.blank? ? nil : [key, fn.call(value)]
+      end.compact.to_h
+    }
+  end
 
   # Filters out elements of the wrong type
-  @@array_of = ->(fn, value) {
-    value.is_a?(Array) ? value.map(&fn).compact : []
-  }.curry
+  def self.array_of(fn)
+    ->(value) {
+      value.is_a?(Array) ? value.map(&fn).compact : []
+    }
+  end
 
   # Provides a default
-  @@default = ->(default, a) { a.blank? ? default : a }.curry
+  def self.default(default)
+    ->(a) { a.blank? ? default : a }.curry
+  end
 
   # Filters out any values not present in the provided array
-  @@one_of = ->(options, a) { options.include?(a) ? a : nil }.curry
+  def self.one_of(options)
+    ->(a) { options.include?(a) ? a : nil }.curry
+  end
 
   # Accepts any scalar value
-  @@scalar = ->(a) { a.is_a?(Array) || a.is_a?(Hash) ? nil : a }
+  def self.scalar
+    ->(a) { a.is_a?(Array) || a.is_a?(Hash) ? nil : a }
+  end
 
   # Accepts any data structure
-  @@anything = :itself.to_proc
+  def self.anything
+    :itself.to_proc
+  end
 end

--- a/spec/controllers/cards_controller_spec.rb
+++ b/spec/controllers/cards_controller_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CardsController, type: :controller do
+  describe 'PUT #update' do
+    before do
+      reader = create :reader, :editor
+      sign_in reader
+    end
+
+    let(:card) { create :card }
+
+    it 'allows :position or :solid to be set' do
+      put :update, format: :json,
+                   params: { id: card, card: { position: 2, solid: true } }
+      card.reload
+      expect(card.position).to be 2
+      expect(card.solid).to be true
+    end
+
+    it 'allows :raw_content to be set with an empty RawDraftContentState' do
+      empty = {
+        'entity_map': {},
+        'blocks': [
+          {
+            'key': 'fnsmj',
+            'text': '',
+            'type': 'unstyled',
+            'depth': 0,
+            'inline_style_ranges': [],
+            'entity_ranges': [],
+            'data': {}
+          }
+        ]
+      }
+
+      put :update, format: :json,
+                   params: { id: card, card: { raw_content: empty } }
+      card.reload
+      expect(card.raw_content['blocks'].map { |x| x['text'] }).to eq ['']
+    end
+
+    it 'allows :raw_content to be set with a complex RawDraftContentState' do
+      complex = {
+        'entity_map': {
+          '0': {
+            'type': 'EDGENOTE',
+            'mutability': 'MUTABLE',
+            'data': { 'slug': 'measure-tolerance-carrying-capacity' }
+          }
+        },
+        'blocks': [
+          {
+            'key': 'al8ts',
+            'text': 'Defining successful wolf management depends on the goals of managing the population and the context for establishing those goals. The DNR notes that the biological carrying capacity and social carrying capacity of wolves should be considered. Biological carrying capacity refers to the concept that the population of a species is limited by the ability of the environment to support it with food, water, and habitat. Social carrying capacity refers to how human tolerance for a species might limit its population. Successful management of wolves,then, means balancing the biological viability of the species and its important role in the ecosystem with the tolerance of the humans who live in its presence. As wildlife biologist David Hammill put it in testifying before the NRC, the viability of the wolf population in the state depends on the ability of humans and wolves to coexist peacefully. As a result, where species are in particular conflict with humans, conflict management is critical to sound scientific decision-making. Management goals are developed to balance ecosystem benefits and human conflicts.',
+            'type': 'unstyled',
+            'depth': 0,
+            'inline_style_ranges': [
+              { 'offset': 153, 'length': 29, 'style': 'BOLD' },
+              { 'offset': 186, 'length': 24, 'style': 'BOLD' }
+            ],
+            'entity_ranges': [
+              { 'offset': 186, 'length': 24, 'key': 0 }
+            ],
+            'data': {}
+          }
+        ]
+      }
+
+      put :update, format: :json,
+                   params: { id: card, card: { raw_content: complex } }
+      card.reload
+      expect(card.raw_content.dig('blocks', 0, 'inlineStyleRanges').count)
+        .to eq 2
+      expect(card.raw_content.dig('entityMap', '0', 'type')).to eq 'EDGENOTE'
+    end
+
+    it 'does not allow :raw_content to have comment threads baked in' do
+      baked_in = {
+        'entity_map': {
+          '0': {
+            'type': 'EDGENOTE',
+            'mutability': 'MUTABLE',
+            'data': { 'slug': 'archive-news-gelman' }
+          }, '1': {
+            'type': 'EDGENOTE',
+            'mutability': 'MUTABLE',
+            'data': { 'slug': 'archive-photo-lagoon' }
+          }, '2': {
+            'type': 'CITATION',
+            'mutability': 'IMMUTABLE',
+            'data': {
+              'contents': '1,4 Dioxane and Pall Life Sciences/Gelman Sciences site. (n.d.). Retrieved July 23, 2017.',
+              'href': 'http://www.a2gov.org/departments/systems-planning/planning-areas/climate-sustainability/pls/Pages/pls.aspx'
+            }
+          }
+        }, 'blocks': [
+          {
+            'key': 'f90f7',
+            'text': 'The company Gelman Sciences sat adjacent to the forest that’s home to the lake. They produced filters to detect water and air pollution, and used the solvent 1,4-dioxane in one step of the production process. To dispose of the chemical, Gelman sprayed it over its lawns and pumped it into unlined lagoons.° While swimming, Bicknell noticed a creek originating from the spray irrigation system, running down from the Gelman Sciences property into Third Sister Lake. The lake contamination was confirmed after that swim when Bicknell took a water sample to the university, revealing moderate levels of 1,4-dioxane.',
+            'type': 'unstyled',
+            'depth': 0,
+            'inline_style_ranges': [
+              { 'offset': 244, 'length': 25, 'style': 'THREAD' },
+              { 'offset': 244, 'length': 25, 'style': 'thread--21' }
+            ],
+            'entity_ranges': [
+              { 'offset': 85, 'length': 122, 'key': 0 },
+              { 'offset': 274, 'length': 30, 'key': 1 },
+              { 'offset': 305, 'length': 1, 'key': 2 }
+            ],
+            'data': {}
+          }
+        ]
+      }
+
+      put :update, format: :json,
+                   params: { id: card, card: { raw_content: baked_in } }
+      card.reload
+      expect(card.raw_content.dig('blocks', 0, 'text').split(' ')[0])
+        .to eq 'The'
+      expect(card.raw_content.dig('blocks', 0, 'inlineStyleRanges').count)
+        .to eq 0
+    end
+  end
+end

--- a/spec/factories/cards.rb
+++ b/spec/factories/cards.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
       {
         entityMap: {},
         blocks: blocks
-      }.to_json
+      }
     end
   end
 end


### PR DESCRIPTION
#85 didn’t actually fix the problem; it just made the problem invisible. We’re now storing cards.raw_content as real objects in the jsonb column, rather than as a stringified blob. This means, now, that we can use the strong parameters idea, although implemented functionally so it can be extended, to strip out the underlines linked to the comment threads.

Migrations: **YES**