### PR TITLE
Adds a publish button to the status bar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,4 +86,6 @@ gem 'mobility'
 
 gem 'rack-canonical-host'
 
+gem 'time_for_a_boolean', git: 'https://github.com/calebthompson/time_for_a_boolean'
+
 ruby '2.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,8 @@ GEM
       tzinfo (~> 1.1)
     acts_as_list (0.7.6)
       activerecord (>= 3.0)
-    addressable (2.4.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (7.1.1)
     authority (3.2.0)
       activesupport (>= 3.0.0)
@@ -101,9 +102,9 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
     byebug (9.0.5)
-    capybara (2.10.1)
+    capybara (2.15.1)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
@@ -217,6 +218,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_mime (0.1.4)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     mobility (0.1.16)
@@ -228,9 +230,8 @@ GEM
     nenv (0.3.0)
     newrelic_rpm (3.16.2.321)
     nio4r (1.2.1)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -258,13 +259,13 @@ GEM
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
     pg (0.18.4)
-    pkg-config (1.1.7)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (3.0.0)
     puma (3.6.0)
-    rack (2.0.2)
+    rack (2.0.3)
     rack-attack (5.0.1)
       rack
     rack-canonical-host (0.2.2)
@@ -388,7 +389,7 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -461,4 +462,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,14 @@ GIT
       omniauth
 
 GIT
+  remote: https://github.com/calebthompson/time_for_a_boolean
+  revision: 636a4c6b4645f9888402ff49b40b7f42c270d946
+  specs:
+    time_for_a_boolean (0.1.0)
+      activerecord
+      railties
+
+GIT
   remote: https://github.com/rails/webpacker
   revision: a06421ffe300e4f32af186f09ed5d1c64b311f5e
   specs:
@@ -442,6 +450,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   table_print
+  time_for_a_boolean!
   tzinfo-data
   uglifier (>= 1.3.0)
   virtus
@@ -452,4 +461,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -46,6 +46,8 @@ class CasesController < ApplicationController
 
   # PATCH/PUT /cases/1
   def update
+    set_group_and_deployment
+
     if @case.update(case_params)
       render :show, status: :ok, location: @case
     else

--- a/app/javascript/overview/Billboard.jsx
+++ b/app/javascript/overview/Billboard.jsx
@@ -69,7 +69,7 @@ const Billboard = ({
       title="Base cover image URL"
       value={baseCoverUrl}
       style={{ color: '#EBEAE4' }}
-      onChange={v => updateCase(slug, { baseCoverUrl: v, coverUrl: v })}
+      onChange={v => updateCase({ baseCoverUrl: v, coverUrl: v })}
     />
     <div className="Card BillboardSnippet pt-light">
       <p className="c-BillboardSnippet__dek">
@@ -79,7 +79,7 @@ const Billboard = ({
           disabled={!editing}
           placeholder="In one concise sentence, provide background and an intriguing twist: get a student to read this case."
           onChange={value => {
-            updateCase(slug, { dek: value })
+            updateCase({ dek: value })
           }}
         />
       </p>
@@ -94,7 +94,7 @@ const Billboard = ({
             value={summary}
             disabled={!editing}
             placeholder="Summarize the case in a short paragraph."
-            onChange={value => updateCase(slug, { summary: value })}
+            onChange={value => updateCase({ summary: value })}
           />
         </p>
       </Less>
@@ -103,7 +103,7 @@ const Billboard = ({
         <LearningObjectives
           disabled={!editing}
           learningObjectives={learningObjectives}
-          onChange={value => updateCase(slug, { learningObjectives: value })}
+          onChange={value => updateCase({ learningObjectives: value })}
         />}
 
       <FlagLinks languages={otherAvailableLocales} slug={slug} />

--- a/app/javascript/overview/StatusBar.jsx
+++ b/app/javascript/overview/StatusBar.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 
 import { FormattedMessage } from 'react-intl'
-import { toggleEditing, saveChanges } from 'redux/actions'
+import { toggleEditing, saveChanges, togglePublished } from 'redux/actions'
 
 import type { State } from 'redux/state'
 
@@ -32,6 +32,7 @@ function StatusBar ({
   edited,
   published,
   toggleEditing,
+  togglePublished,
   saveChanges,
 }) {
   const elements: Array<?BarElement> = [
@@ -47,6 +48,14 @@ function StatusBar ({
 
     // Save changes
     edited ? { message: 'save', onClick: saveChanges } : null,
+
+    // Publish the case
+    editable && !editing && !edited
+      ? {
+        message: published ? 'unpublishCase' : 'publishCase',
+        onClick: togglePublished,
+      }
+      : null,
   ]
 
   if (!elements.some(x => x)) return null
@@ -74,9 +83,11 @@ function StatusBar ({
   )
 }
 
-export default connect(mapStateToProps, { toggleEditing, saveChanges })(
-  StatusBar
-)
+export default connect(mapStateToProps, {
+  toggleEditing,
+  saveChanges,
+  togglePublished,
+})(StatusBar)
 
 const Bar = styled.div`
   width: 100%;

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -232,10 +232,7 @@ export type UpdateCaseAction = {
   type: 'UPDATE_CASE',
   data: $Shape<CaseDataState>,
 }
-export function updateCase (
-  slug: string,
-  data: $Shape<CaseDataState>
-): UpdateCaseAction {
+export function updateCase (data: $Shape<CaseDataState>): UpdateCaseAction {
   setUnsaved()
   return { type: 'UPDATE_CASE', data }
 }

--- a/app/javascript/redux/actions.js
+++ b/app/javascript/redux/actions.js
@@ -237,6 +237,18 @@ export function updateCase (data: $Shape<CaseDataState>): UpdateCaseAction {
   return { type: 'UPDATE_CASE', data }
 }
 
+export function togglePublished (): ThunkAction {
+  return (dispatch: Dispatch, getState: GetState) => {
+    const state = getState()
+    if (
+      window.confirm('Are you sure you want to change the publication status?')
+    ) {
+      dispatch(updateCase({ published: !state.caseData.published }))
+      dispatch(saveChanges())
+    }
+  }
+}
+
 export function enrollReader (readerId: string, caseSlug: string): ThunkAction {
   return async (dispatch: Dispatch) => {
     const enrollment = await Orchard.espalier(

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -10,6 +10,8 @@ class Case < ApplicationRecord
              fallbacks: true
   enum catalog_position: %i[in_index featured]
 
+  time_for_a_boolean :published
+
   resourcify
 
   has_many :activities, dependent: :destroy
@@ -26,11 +28,10 @@ class Case < ApplicationRecord
   has_many :deployments, dependent: :destroy
   has_many :quizzes, dependent: :destroy
 
-  scope :published, -> { where(published: true) }
+  scope :published, -> { where.not(published_on: nil) }
 
   validates :slug, presence: true, uniqueness: true
   validates_format_of :slug, with: /\A[a-z0-9-]+\Z/
-  validates :publication_date, presence: true, if: :published?
 
   after_create :create_forum_for_global_community
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -37,9 +37,9 @@ class Case < ApplicationRecord
 
   def <=>(other)
     return published ? 1 : -1 if published ^ other.try(:published)
-    return publication_date.nil? ? -1 : 1 if publication_date.nil? ||
-                                             other.publication_date.nil?
-    publication_date <=> other.publication_date
+    return published_at.nil? ? -1 : 1 if published_at.nil? ||
+                                         other.published_at.nil?
+    published_at <=> other.published_at
   end
 
   def create_forum_for_global_community

--- a/app/views/cases/index.html.haml
+++ b/app/views/cases/index.html.haml
@@ -23,8 +23,8 @@
             %img.admin-case-cover-thumbnail{src: ix_cover_image(kase, :small)}
           %td=kase.kicker.upcase
           %td=kase.catalog_position.humanize.titlecase
-          %td{class: "admin-case-date#{kase.publication_date.nil? ? '--forthcoming' : '--published'}"}
-            =kase.publication_date || "Forthcoming"
+          %td{class: "admin-case-date#{kase.published_at.nil? ? '--forthcoming' : '--published'}"}
+            =kase.published_at || "Forthcoming"
           -#%td
           %td
             = button_to "Edit Case", case_path(kase, anchor: "/edit"),

--- a/config/locales/react.json
+++ b/config/locales/react.json
@@ -22,6 +22,8 @@
     "statusBar.endEdit": "Stop editing this case",
     "statusBar.editInstructions": "To edit this case, just change the text",
     "statusBar.save": "Save",
+    "statusBar.publishCase": "Publish this case",
+    "statusBar.unpublishCase": "Unpublish this case",
     "podcast.hosts": "with {count, plural, one {host} other {hosts}}",
     "create": "Create",
     "overview.otherLanguages":

--- a/db/migrate/20170830201129_change_published_to_timestamp.rb
+++ b/db/migrate/20170830201129_change_published_to_timestamp.rb
@@ -1,0 +1,24 @@
+class ChangePublishedToTimestamp < ActiveRecord::Migration[5.0]
+  def change
+    add_column :cases, :published_at, :timestamp
+
+    reversible do |dir|
+      dir.up do
+        Case.find_each do |c|
+          c.published_at = c.published ? c.publication_date : nil
+          c.save
+        end
+      end
+      dir.down do
+        Case.find_each do |c|
+          c.publication_date = c.published_at
+          c.published = !!c.published_at
+          c.save
+        end
+      end
+    end
+
+    remove_column :cases, :publication_date, :date
+    remove_column :cases, :published, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170830013418) do
+ActiveRecord::Schema.define(version: 20170830201129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,15 +91,13 @@ ActiveRecord::Schema.define(version: 20170830013418) do
   end
 
   create_table "cases", force: :cascade do |t|
-    t.boolean  "published",           default: false
-    t.text     "slug",                                null: false
-    t.string   "authors",             default: [],                 array: true
-    t.text     "tags",                default: [],                 array: true
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.text     "slug",                             null: false
+    t.string   "authors",             default: [],              array: true
+    t.text     "tags",                default: [],              array: true
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.string   "cover_url"
-    t.date     "publication_date"
-    t.integer  "catalog_position",    default: 0,     null: false
+    t.integer  "catalog_position",    default: 0,  null: false
     t.text     "short_title"
     t.text     "photo_credit"
     t.boolean  "commentable"
@@ -112,6 +110,7 @@ ActiveRecord::Schema.define(version: 20170830013418) do
     t.jsonb    "learning_objectives"
     t.jsonb    "audience"
     t.jsonb    "classroom_timeline"
+    t.datetime "published_at"
     t.index ["slug"], name: "index_cases_on_slug", unique: true, using: :btree
     t.index ["tags"], name: "index_cases_on_tags", using: :gin
   end

--- a/spec/factories/cases.rb
+++ b/spec/factories/cases.rb
@@ -16,8 +16,7 @@ FactoryGirl.define do
     end
 
     trait :published do
-      published true
-      publication_date { Time.zone.now }
+      published_at { Time.zone.now }
     end
 
     factory :case_with_elements do

--- a/spec/features/publishing_a_case_spec.rb
+++ b/spec/features/publishing_a_case_spec.rb
@@ -9,14 +9,18 @@ feature 'Publishing a case' do
   scenario 'works' do
     login_as reader
     visit case_path('en', kase)
-    find('a', text: 'Publish this case').click
 
-    accept_confirm 'Are you sure you want to change the publication status?'
+    accept_confirm 'Are you sure you want to change the publication status?' do
+      find('a', text: 'Publish this case').click
+    end
+    sleep(1)
     page.driver.browser.navigate.refresh
     expect(page).to have_content 'Unpublish this case'
 
-    find('a', text: 'Unpublish this case').click
-    accept_confirm 'Are you sure you want to change the publication status?'
+    accept_confirm 'Are you sure you want to change the publication status?' do
+      find('a', text: 'Unpublish this case').click
+    end
+    sleep(1)
     page.driver.browser.navigate.refresh
     expect(page).to have_content 'Publish this case'
   end

--- a/spec/features/publishing_a_case_spec.rb
+++ b/spec/features/publishing_a_case_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Publishing a case' do
+  let!(:kase) { create :case_with_elements }
+  let!(:reader) { create :reader, :editor }
+
+  scenario 'works' do
+    login_as reader
+    visit case_path('en', kase)
+    find('a', text: 'Publish this case').click
+
+    accept_confirm 'Are you sure you want to change the publication status?'
+    page.driver.browser.navigate.refresh
+    expect(page).to have_content 'Unpublish this case'
+
+    find('a', text: 'Unpublish this case').click
+    accept_confirm 'Are you sure you want to change the publication status?'
+    page.driver.browser.navigate.refresh
+    expect(page).to have_content 'Publish this case'
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu] }
+    chrome_options: { args: %w[headless disable-gpu] }
   )
 
   Capybara::Selenium::Driver.new app,


### PR DESCRIPTION
This PR adds a publish/unpublish toggle to the status bar when users are in editor role and has saved all the changes. 

The button reverses the published state of the case, after confirmation, and uses the normal `saveChanges` pathway to persist it. 