### PR TITLE
Cache thread-attached cards per user as well as per forum

### DIFF
--- a/app/views/comment_threads/index.json.jbuilder
+++ b/app/views/comment_threads/index.json.jbuilder
@@ -8,7 +8,7 @@ by_id json,
 
 json.cards do
   @case.cards.each do |card|
-    json.cache! [card, @forum] do
+    json.cache! [card, @forum, current_reader] do
       json.set! card.to_param do
         json.extract! card, :id, :position, :solid, :raw_content
         json.content card.content || ''


### PR DESCRIPTION
So that threads with no responses that one user starts aren’t served to
other users