### PR TITLE
Moves bulky data from case partial for quick rendering on catalog

### DIFF
--- a/app/views/cases/_case.json.jbuilder
+++ b/app/views/cases/_case.json.jbuilder
@@ -3,10 +3,8 @@
 json.key_format! camelize: :lower
 
 json.extract! c, :slug, :published_at, :kicker, :title, :dek, :authors,
-              :translators, :summary, :tags, :photo_credit,
-              :latitude, :longitude, :zoom,
-              :other_available_locales, :commentable, :learning_objectives,
-              :audience, :featured_at
+              :translators, :tags, :photo_credit, :latitude, :longitude, :zoom,
+              :featured_at
 
 json.authors_string c.authors.to_sentence
 json.translators_string translators_string c
@@ -15,10 +13,4 @@ json.base_cover_url c.cover_url
 json.small_cover_url ix_cover_image(c, :small)
 json.cover_url ix_cover_image(c, :billboard)
 
-json.case_elements c.case_elements do |case_element|
-  json.cache! case_element do
-    json.partial! case_element
-  end
-end
-
-json.url case_url I18n.locale, c
+json.url case_path I18n.locale, c

--- a/app/views/cases/_show.json.jbuilder
+++ b/app/views/cases/_show.json.jbuilder
@@ -4,6 +4,15 @@ json.key_format! camelize: :lower
 
 json.cache! c do
   json.partial! 'case', c: c
+
+  json.extract! c, :summary, :other_available_locales, :commentable,
+                :learning_objectives, :audience
+
+  json.case_elements c.case_elements do |case_element|
+    json.cache! case_element do
+      json.partial! case_element
+    end
+  end
 end
 
 by_id json,


### PR DESCRIPTION
This is in place of using ActiveModel::Serializers. I made a go of that because they are faster by far, especially compared to partial lookup with jbuilder. It’s just too much work to get them to generate the JSON we need, and there's no way it’s worth it to switch everything to JSON-API format.

Besides, what is it with that and arrays? I want my data to be in normalized, keyed tables for easy cross referencing. AM::S seems really insistent that has_many associations be an array, when I usually don't care about order (at the highest level, at least)

Until maybe we switch to GraphQL someday, it’ll have to suffice to cache jbuilder partial lookup aggressively and be smart about how much unneeded data we’re sending over the wire. Serialization ain’t free.

Closes #138 