### PR TITLE
Cache case partials by key varying on locale

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,7 +63,7 @@ MD
       json.set! key do
         collection.each do |element|
           json.set! element.to_param do
-            json.cache! element do
+            json.cache! [element, I18n.locale] do
               json.partial! element
             end
           end

--- a/app/views/cases/_show.json.jbuilder
+++ b/app/views/cases/_show.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.key_format! camelize: :lower
 
-json.cache! c do
+json.cache! [c, I18n.locale] do
   json.partial! 'case', c: c
 
   json.extract! c, :summary, :other_available_locales, :commentable,


### PR DESCRIPTION
Otherwise, we’ll always return whatever language is first loaded!