### PR TITLE
Fixes multiline photo credits for edgenotes

### DIFF
--- a/app/javascript/edgenotes/Edgenote.jsx
+++ b/app/javascript/edgenotes/Edgenote.jsx
@@ -270,6 +270,7 @@ const Image = ({
         (editing || photoCredit) && (
           <PhotoCredit>
             <EditableText
+              multiline
               value={photoCredit}
               disabled={!editing}
               placeholder={editing ? 'Photo credit' : ''}


### PR DESCRIPTION
Multiline values set in the old format edgenotes completely broke the
editing interface of the new format, which didn’t allow them